### PR TITLE
Fix deduplication for "message" type long-term memories

### DIFF
--- a/agent-memory-client/agent_memory_client/models.py
+++ b/agent-memory-client/agent_memory_client/models.py
@@ -7,7 +7,7 @@ For full model definitions, see the main agent_memory_server package.
 
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Any, Literal, TypedDict
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 from ulid import ULID
@@ -48,11 +48,19 @@ class MemoryTypeEnum(str, Enum):
     MESSAGE = "message"
 
 
-class MemoryMessage(TypedDict):
+class MemoryMessage(BaseModel):
     """A message in the memory system"""
 
     role: str
     content: str
+    id: str = Field(
+        default_factory=lambda: str(ULID()),
+        description="Unique identifier for the message (auto-generated)",
+    )
+    persisted_at: datetime | None = Field(
+        default=None,
+        description="Server-assigned timestamp when message was persisted to long-term storage",
+    )
 
 
 class MemoryRecord(BaseModel):
@@ -134,9 +142,9 @@ class WorkingMemory(BaseModel):
     """Working memory for a session - contains both messages and structured memory records"""
 
     # Support both message-based memory (conversation) and structured memory records
-    messages: list[dict[str, Any]] = Field(
+    messages: list[MemoryMessage] = Field(
         default_factory=list,
-        description="Conversation messages (role/content pairs)",
+        description="Conversation messages with tracking fields",
     )
     memories: list[MemoryRecord | ClientMemoryRecord] = Field(
         default_factory=list,

--- a/agent_memory_server/models.py
+++ b/agent_memory_server/models.py
@@ -67,6 +67,14 @@ class MemoryMessage(BaseModel):
 
     role: str
     content: str
+    id: str = Field(
+        default_factory=lambda: str(ULID()),
+        description="Unique identifier for the message (auto-generated if not provided)",
+    )
+    persisted_at: datetime | None = Field(
+        default=None,
+        description="Server-assigned timestamp when message was persisted to long-term storage",
+    )
 
 
 class SessionListResponse(BaseModel):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -89,10 +89,22 @@ class TestMemoryEndpoints:
 
         data = response.json()
         response = WorkingMemoryResponse(**data)
-        assert response.messages == [
-            MemoryMessage(role="user", content="Hello"),
-            MemoryMessage(role="assistant", content="Hi there"),
-        ]
+
+        # Check that we have 2 messages with correct roles and content
+        assert len(response.messages) == 2
+
+        # Check message content and roles (IDs are auto-generated so we can't compare directly)
+        message_contents = [msg.content for msg in response.messages]
+        message_roles = [msg.role for msg in response.messages]
+        assert "Hello" in message_contents
+        assert "Hi there" in message_contents
+        assert "user" in message_roles
+        assert "assistant" in message_roles
+
+        # Check that all messages have IDs (auto-generated)
+        for msg in response.messages:
+            assert msg.id is not None
+            assert len(msg.id) > 0
 
         roles = [msg["role"] for msg in data["messages"]]
         contents = [msg["content"] for msg in data["messages"]]

--- a/tests/test_client_api.py
+++ b/tests/test_client_api.py
@@ -116,8 +116,8 @@ async def test_session_lifecycle(memory_test_client: MemoryAPIClient):
 
         # Step 1: Create new session memory
         response = await memory_test_client.put_working_memory(session_id, memory)
-        assert response.messages[0]["content"] == "Hello from the client!"
-        assert response.messages[1]["content"] == "Hi there, I'm the memory server!"
+        assert response.messages[0].content == "Hello from the client!"
+        assert response.messages[1].content == "Hi there, I'm the memory server!"
         assert response.context == "This is a test session created by the API client."
 
     # Next, mock GET response for retrieving session memory
@@ -132,8 +132,8 @@ async def test_session_lifecycle(memory_test_client: MemoryAPIClient):
         # Step 2: Retrieve the session memory
         session = await memory_test_client.get_working_memory(session_id)
         assert len(session.messages) == 2
-        assert session.messages[0]["content"] == "Hello from the client!"
-        assert session.messages[1]["content"] == "Hi there, I'm the memory server!"
+        assert session.messages[0].content == "Hello from the client!"
+        assert session.messages[1].content == "Hi there, I'm the memory server!"
         assert session.context == "This is a test session created by the API client."
 
     # Mock list sessions

--- a/tests/test_client_enhancements.py
+++ b/tests/test_client_enhancements.py
@@ -551,9 +551,9 @@ class TestEnhancedConvenienceMethods:
             # Check that messages were appended
             working_memory_arg = mock_put.call_args[0][1]
             assert len(working_memory_arg.messages) == 3
-            assert working_memory_arg.messages[0]["content"] == "First message"
-            assert working_memory_arg.messages[1]["content"] == "Second message"
-            assert working_memory_arg.messages[2]["content"] == "Third message"
+            assert working_memory_arg.messages[0].content == "First message"
+            assert working_memory_arg.messages[1].content == "Second message"
+            assert working_memory_arg.messages[2].content == "Third message"
 
     def test_deep_merge_dicts(self, enhanced_test_client):
         """Test the deep merge dictionary utility method."""


### PR DESCRIPTION
The memory server indexes any messages from working memory into "message" type memory records in long-term memory. However, we were not attempting to deduplicate these memory records -- only the higher-level long-term memory types, like semantic and episodic memory.

This change refactors the logic we use to store messages long-term such that they work similarly to long-term memories the client adds to working memory. When a client adds a message to working memory, the client gives the memory an ID, and the memory gets a blank `persisted_at` timestamp. After setting working memory, we kick off a background task to persist any promoted long-term memories and messages in long-term memory. When we copy the messages into long-term memory, we now update the `persisted_at` timestamp. If we see that working memory again and try to persist any new memories or messages, we'll skip any that have already been persisted.