### PR TITLE
Make compaction schedule configurable

### DIFF
--- a/agent_memory_server/config.py
+++ b/agent_memory_server/config.py
@@ -158,6 +158,9 @@ Optimized query:"""
     # Keep only top N most recent (by recency score) when budget is set
     forgetting_budget_keep_top_n: int | None = None
 
+    # Compaction settings
+    compaction_every_minutes: int = 10
+
     class Config:
         env_file = ".env"
         env_file_encoding = "utf-8"

--- a/agent_memory_server/long_term_memory.py
+++ b/agent_memory_server/long_term_memory.py
@@ -428,7 +428,9 @@ async def compact_long_term_memories(
     vector_distance_threshold: float = 0.12,
     compact_hash_duplicates: bool = True,
     compact_semantic_duplicates: bool = True,
-    perpetual: Perpetual = Perpetual(every=timedelta(minutes=10), automatic=True),
+    perpetual: Perpetual = Perpetual(
+        every=timedelta(minutes=settings.compaction_every_minutes), automatic=True
+    ),
 ) -> int:
     """
     Compact long-term memories by merging duplicates and semantically similar memories.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -114,13 +114,17 @@ QUERY_OPTIMIZATION_PROMPT_TEMPLATE="Transform this query for semantic search..."
 
 ## Memory Lifecycle
 
-### Forgetting Configuration
+### Memory Management Configuration
 ```bash
+# Forgetting settings
 FORGETTING_ENABLED=false          # Enable automatic forgetting (default: false)
 FORGETTING_EVERY_MINUTES=60       # Run forgetting every N minutes (default: 60)
 FORGETTING_MAX_AGE_DAYS=30        # Delete memories older than N days
 FORGETTING_MAX_INACTIVE_DAYS=7    # Delete memories inactive for N days
 FORGETTING_BUDGET_KEEP_TOP_N=1000 # Keep only top N most recent memories
+
+# Compaction settings
+COMPACTION_EVERY_MINUTES=10       # Run memory compaction every N minutes (default: 10)
 ```
 
 ## Background Tasks
@@ -209,6 +213,7 @@ enable_topic_extraction: true
 enable_ner: true
 forgetting_enabled: true
 forgetting_max_age_days: 90
+compaction_every_minutes: 15
 ```
 
 ### High-Performance Setup

--- a/docs/memory-lifecycle.md
+++ b/docs/memory-lifecycle.md
@@ -357,7 +357,7 @@ async def cleanup_working_memory(client: MemoryAPIClient):
 
 ### Background Compaction
 
-The system automatically runs compaction tasks every 10 minutes to:
+The system automatically runs compaction tasks (configurable, default every 10 minutes) to:
 
 - Merge similar memories
 - Update embeddings for improved accuracy
@@ -376,6 +376,18 @@ await client.schedule_compaction(
     run_at=datetime.now() + timedelta(hours=1),
     full_rebuild=False
 )
+```
+
+#### Configuring Compaction Schedule
+
+The frequency of automatic compaction can be configured:
+
+```bash
+# Environment variable (minutes)
+COMPACTION_EVERY_MINUTES=15
+
+# Or in configuration file
+compaction_every_minutes: 15
 ```
 
 ### Compaction Strategies


### PR DESCRIPTION
Add compaction_every_minutes setting to replace hardcoded 10-minute schedule. Users can now configure via environment variable or config file.

Fixes #53

🤖 Generated with [Claude Code](https://claude.ai/code)