### PR TITLE
Update memory documentation patterns to use working memory sessions

### DIFF
--- a/TASK_MEMORY.md
+++ b/TASK_MEMORY.md
@@ -1,0 +1,35 @@
+# Task Memory
+
+**Created:** 2025-08-27 14:47:59
+**Branch:** feature/make-some-changes
+
+## Requirements
+
+Make some changes to the docs. First, reorganize all early examples that use 'memory_prompt' to first get a working memory session, and then pass the session ID to 'memory_prompt'. Working memory should be the first thing clients work with: you can get it, you don't have to explicitly create it. 2. Rename 'Memory Integration Patterns' to 'Memory Patterns.' 3. Rename the 'Integration' section to 'Using Memory'. Then let's pause and evaluate.
+
+## Development Notes
+
+*Update this section as you work on the task. Include:*
+- *Progress updates*
+- *Key decisions made*
+- *Challenges encountered*
+- *Solutions implemented*
+- *Files modified*
+- *Testing notes*
+
+### Work Log
+
+- [2025-08-27 14:47:59] Task setup completed, TASK_MEMORY.md created
+- [2025-08-27 14:52:00] Set up development environment with uv venv and sync --all-extras
+- [2025-08-27 14:53:00] Identified documentation files with memory_prompt examples
+- [2025-08-27 14:53:30] Found memory-integration-patterns.md as main target file
+- [2025-08-27 14:54:00] Analyzed current memory_prompt pattern - examples call memory_prompt with session object directly
+- [2025-08-27 14:54:30] Need to reorganize to: 1) get working memory session first, 2) pass session_id to memory_prompt
+- [2025-08-27 14:55:00] Successfully updated all memory_prompt examples to use working memory session pattern
+- [2025-08-27 14:55:30] Renamed 'Memory Integration Patterns' to 'Memory Patterns' in title
+- [2025-08-27 14:56:00] Renamed 'Overview of Integration Patterns' section to 'Overview of Using Memory'
+- [2025-08-27 14:56:30] All requested changes completed successfully
+
+---
+
+*This file serves as your working memory for this task. Keep it updated as you progress through the implementation.*


### PR DESCRIPTION
Reorganize memory_prompt examples to first get working memory session, then pass session_id parameter. Rename 'Memory Integration Patterns' to 'Memory Patterns' and 'Integration' section to 'Using Memory'.

🤖 Generated with [Claude Code](https://claude.ai/code)