### PR TITLE
Change optimize_query default to False in client

### DIFF
--- a/agent-memory-client/agent_memory_client/__init__.py
+++ b/agent-memory-client/agent_memory_client/__init__.py
@@ -5,7 +5,7 @@ A Python client for the Agent Memory Server REST API providing comprehensive
 memory management capabilities for AI agents and applications.
 """
 
-__version__ = "0.12.5"
+__version__ = "0.12.6"
 
 from .client import MemoryAPIClient, MemoryClientConfig, create_memory_client
 from .exceptions import (

--- a/agent-memory-client/agent_memory_client/client.py
+++ b/agent-memory-client/agent_memory_client/client.py
@@ -764,7 +764,7 @@ class MemoryAPIClient:
         recency: RecencyConfig | None = None,
         limit: int = 10,
         offset: int = 0,
-        optimize_query: bool = True,
+        optimize_query: bool = False,
     ) -> MemoryRecordResults:
         """
         Search long-term memories using semantic search and filters.

--- a/tests/test_client_api.py
+++ b/tests/test_client_api.py
@@ -499,10 +499,10 @@ async def test_memory_prompt_integration(memory_test_client: MemoryAPIClient):
 
 
 @pytest.mark.asyncio
-async def test_search_long_term_memory_with_optimize_query_default_true(
+async def test_search_long_term_memory_with_optimize_query_default_false(
     memory_test_client: MemoryAPIClient,
 ):
-    """Test that client search_long_term_memory uses optimize_query=True by default."""
+    """Test that client search_long_term_memory uses optimize_query=False by default."""
     with patch(
         "agent_memory_server.long_term_memory.search_long_term_memories"
     ) as mock_search:
@@ -519,15 +519,15 @@ async def test_search_long_term_memory_with_optimize_query_default_true(
             next_offset=None,
         )
 
-        # Call search without optimize_query parameter (should default to True)
+        # Call search without optimize_query parameter (should default to False)
         results = await memory_test_client.search_long_term_memory(
             text="tell me about my preferences"
         )
 
-        # Verify search was called with optimize_query=True (default)
+        # Verify search was called with optimize_query=False (default)
         mock_search.assert_called_once()
         call_kwargs = mock_search.call_args.kwargs
-        assert call_kwargs.get("optimize_query") is True
+        assert call_kwargs.get("optimize_query") is False
 
         # Verify results
         assert results.total == 1
@@ -535,10 +535,10 @@ async def test_search_long_term_memory_with_optimize_query_default_true(
 
 
 @pytest.mark.asyncio
-async def test_search_long_term_memory_with_optimize_query_false_explicit(
+async def test_search_long_term_memory_with_optimize_query_true_explicit(
     memory_test_client: MemoryAPIClient,
 ):
-    """Test that client search_long_term_memory can use optimize_query=False when explicitly set."""
+    """Test that client search_long_term_memory can use optimize_query=True when explicitly set."""
     with patch(
         "agent_memory_server.long_term_memory.search_long_term_memories"
     ) as mock_search:
@@ -555,15 +555,15 @@ async def test_search_long_term_memory_with_optimize_query_false_explicit(
             next_offset=None,
         )
 
-        # Call search with explicit optimize_query=False
+        # Call search with explicit optimize_query=True
         await memory_test_client.search_long_term_memory(
-            text="tell me about my preferences", optimize_query=False
+            text="tell me about my preferences", optimize_query=True
         )
 
-        # Verify search was called with optimize_query=False
+        # Verify search was called with optimize_query=True
         mock_search.assert_called_once()
         call_kwargs = mock_search.call_args.kwargs
-        assert call_kwargs.get("optimize_query") is False
+        assert call_kwargs.get("optimize_query") is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Changes

- Changed the default value of `optimize_query` parameter from `True` to `False` in the client's `search_long_term_memory` function
- Updated tests to verify the new default behavior
- Bumped client version from 0.12.5 to 0.12.6

## Rationale

This change reduces unnecessary LLM calls for query optimization by defaulting to `False`. Users can still explicitly enable optimization when needed by passing `optimize_query=True`.

## Testing

- All existing tests pass
- Updated test `test_search_long_term_memory_with_optimize_query_default_false` to verify the new default
- Updated test `test_search_long_term_memory_with_optimize_query_true_explicit` to verify explicit override still works