### PR TITLE
Allow token add to accept pre-generated tokens

### DIFF
--- a/tests/test_token_cli.py
+++ b/tests/test_token_cli.py
@@ -95,6 +95,52 @@ class TestTokenCLI:
         mock_redis.expire.assert_called_once()
         mock_redis.sadd.assert_called_once()
 
+    @patch("agent_memory_server.auth.generate_token")
+    @patch("agent_memory_server.cli.get_redis_conn")
+    def test_token_add_command_with_provided_token(
+        self,
+        mock_get_redis,
+        mock_generate_token,
+        mock_redis,
+        cli_runner,
+    ):
+        """Test token add command when a token is provided via --token."""
+        mock_get_redis.return_value = mock_redis
+
+        import json
+
+        provided_token = "test-token-123"
+
+        result = cli_runner.invoke(
+            token,
+            [
+                "add",
+                "--description",
+                "Test token",
+                "--expires-days",
+                "7",
+                "--token",
+                provided_token,
+                "--format",
+                "json",
+            ],
+        )
+
+        assert result.exit_code == 0
+
+        data = json.loads(result.output)
+        assert data["token"] == provided_token
+        assert data["description"] == "Test token"
+        assert data["expires_at"] is not None
+
+        # generate_token should not be called when a token is provided
+        mock_generate_token.assert_not_called()
+
+        # Verify Redis calls
+        mock_redis.set.assert_called_once()
+        mock_redis.expire.assert_called_once()
+        mock_redis.sadd.assert_called_once()
+
     @patch("agent_memory_server.cli.get_redis_conn")
     def test_token_list_command_empty(self, mock_get_redis, mock_redis, cli_runner):
         """Test token list command with no tokens."""


### PR DESCRIPTION
Add support for providing a pre-generated token value to the token add CLI command.

- Introduce a new --token option for agent-memory token add
- Reuse existing hashing, storage, and expiration logic for provided tokens
- Preserve existing behavior when --token is not specified (token is generated as before)
- Integrate provided tokens with the existing JSON output mode (token field reflects the provided value)
- Add tests to verify behavior and ensure generate_token is not called when --token is supplied