### PR TITLE
feat(config): make extraction debounce TTL configurable

### DIFF
--- a/agent_memory_server/config.py
+++ b/agent_memory_server/config.py
@@ -328,6 +328,11 @@ class Settings(BaseSettings):
     # skipping the startup scan and per-read type checks for better performance.
     working_memory_migration_complete: bool = False
 
+    # Long-term memory extraction settings
+    # Debounce period (in seconds) for thread-aware memory extraction.
+    # Prevents constant re-extraction as new messages arrive in a conversation.
+    extraction_debounce_seconds: int = 300  # 5 minutes
+
     # Query optimization settings
     query_optimization_prompt_template: str = """Transform this natural language query into an optimized version for semantic search. The goal is to make it more effective for finding semantically similar content while preserving the original intent.
 

--- a/agent_memory_server/long_term_memory.py
+++ b/agent_memory_server/long_term_memory.py
@@ -144,7 +144,6 @@ Extracted memories:
 logger = logging.getLogger(__name__)
 
 # Debounce configuration for thread-aware extraction
-EXTRACTION_DEBOUNCE_TTL = 300  # 5 minutes
 EXTRACTION_DEBOUNCE_KEY_PREFIX = "extraction_debounce"
 
 
@@ -169,9 +168,10 @@ async def should_extract_session_thread(session_id: str, redis: Redis) -> bool:
     exists = await redis.exists(debounce_key)
     if not exists:
         # Set debounce key with TTL to prevent extraction for the next period
-        await redis.setex(debounce_key, EXTRACTION_DEBOUNCE_TTL, "extracting")
+        debounce_ttl = settings.extraction_debounce_seconds
+        await redis.setex(debounce_key, debounce_ttl, "extracting")
         logger.info(
-            f"Starting thread-aware extraction for session {session_id} (debounce set for {EXTRACTION_DEBOUNCE_TTL}s)"
+            f"Starting thread-aware extraction for session {session_id} (debounce set for {debounce_ttl}s)"
         )
         return True
 


### PR DESCRIPTION
  - Add EXTRACTION_DEBOUNCE_SECONDS environment variable to configure the debounce period for thread-aware long-term memory extraction
  - Default remains 300 seconds (5 minutes) for backward compatibility
  - 
Set the environment variable to customize the debounce period:

  # Reduce to 1 minute
  EXTRACTION_DEBOUNCE_SECONDS=60

  # Increase to 10 minutes  
  EXTRACTION_DEBOUNCE_SECONDS=600