### PR TITLE
Fix import errors in summary_views.py and improve test coverage

### DIFF
--- a/agent_memory_server/__init__.py
+++ b/agent_memory_server/__init__.py
@@ -1,3 +1,3 @@
 """Redis Agent Memory Server - A memory system for conversational AI."""
 
-__version__ = "0.13.0"
+__version__ = "0.13.1"


### PR DESCRIPTION
## Summary

Fixes a `ModuleNotFoundError` in `summary_views.py` caused by importing from the non-existent `agent_memory_server.llms` module instead of the correct `agent_memory_server.llm` module.

## Changes

### Fixed Import Errors in `agent_memory_server/summary_views.py`:
1. **Line 346**: Changed `from agent_memory_server.llms import get_model_config` to `from agent_memory_server.llm import get_model_config`
2. **Lines 445-478**: Changed `from agent_memory_server.llms import get_model_client` to `from agent_memory_server.llm import LLMClient` and updated the LLM call pattern to use the classmethod approach

### Improved Test Coverage in `tests/test_summary_views.py`:
- Fixed fixture references from `redis_client` to `async_redis_client`
- Fixed `SummaryView` source validation to use valid values
- Fixed Task creation to use proper `Task` object
- Fixed import from `get_task_status` to `get_task`
- Added test isolation by mocking `list_summary_views` in periodic refresh tests
- Added new tests for edge cases (large memory sets, exception handling, token budget handling)
- **Test coverage improved from 58% to 98%**

### Version Bump:
- Bumped version from `0.13.0` to `0.13.1`

## Testing

- All 64 tests in `tests/test_summary_views.py` pass
- All 569 tests in the full test suite pass
- Pre-commit hooks pass

## Verification

Confirmed no other modules have similar import issues by running:
```bash
grep -r "from agent_memory_server.llms" --include="*.py" .
# No matches found
```

