### PR TITLE
Fix empty text causing OpenAI embeddings API error

### DIFF
--- a/agent_memory_server/__init__.py
+++ b/agent_memory_server/__init__.py
@@ -1,3 +1,3 @@
 """Redis Agent Memory Server - A memory system for conversational AI."""
 
-__version__ = "0.13.0"
+__version__ = "0.13.1"

--- a/agent_memory_server/llm/embeddings.py
+++ b/agent_memory_server/llm/embeddings.py
@@ -159,9 +159,21 @@ class LiteLLMEmbeddings(Embeddings):
 
         Returns:
             List of embedding vectors.
+
+        Raises:
+            ValueError: If any text in the list is empty (OpenAI rejects empty strings).
         """
         if not texts:
             return []
+
+        # Validate that no texts are empty - OpenAI rejects empty strings with
+        # "'$.input' is invalid" error
+        for i, text in enumerate(texts):
+            if not text:
+                raise ValueError(
+                    f"Cannot embed empty string at index {i}. "
+                    "OpenAI's embedding API rejects empty strings."
+                )
 
         kwargs = self._build_call_kwargs(texts)
         response = embedding(**kwargs)
@@ -188,9 +200,21 @@ class LiteLLMEmbeddings(Embeddings):
 
         Returns:
             List of embedding vectors.
+
+        Raises:
+            ValueError: If any text in the list is empty (OpenAI rejects empty strings).
         """
         if not texts:
             return []
+
+        # Validate that no texts are empty - OpenAI rejects empty strings with
+        # "'$.input' is invalid" error
+        for i, text in enumerate(texts):
+            if not text:
+                raise ValueError(
+                    f"Cannot embed empty string at index {i}. "
+                    "OpenAI's embedding API rejects empty strings."
+                )
 
         kwargs = self._build_call_kwargs(texts)
         response = await aembedding(**kwargs)


### PR DESCRIPTION
## Problem

The `compact_long_term_memories` background task failed with:
```
litellm.exceptions.BadRequestError: OpenAIException - Error code: 400 -
{'error': {'message': "'$.input' is invalid..."}}
```

This occurred because a memory with empty text was passed to OpenAI's embedding API, which rejects empty strings.

## Root Cause

A memory with empty `id` and empty `text` somehow existed in the database:
```json
{"id":"","text":"","session_id":null,"user_id":null,"namespace":null,...}
```

## Solution

Two-layer approach:

### 1. Reject empty text at API layer
Prevent new memories with empty text from being created:
- `CreateMemoryRecordRequest`: Added model validator to reject memories with empty text/id
- `UpdateWorkingMemory`: Added model validator to reject memories with empty text/id  
- `LenientMemoryRecord`: Added model validator to reject empty text

### 2. Filter legacy data gracefully
Handle existing invalid memories that may exist in databases:
- `index_long_term_memories`: Filter out memories with empty text/id before processing
- `deduplicate_by_semantic_search`: Skip deduplication for empty text
- `embed_documents`/`aembed_documents`: Raise clear `ValueError` for empty strings

## Changes

| File | Change |
|------|--------|
| `agent_memory_server/models.py` | Add validation to request models |
| `agent_memory_server/long_term_memory.py` | Filter invalid memories during indexing |
| `agent_memory_server/llm/embeddings.py` | Validate inputs before calling OpenAI |
| `tests/integration/test_deduplication_e2e.py` | Tests for API rejection and legacy handling |

## Test Results

- **602 passed**, 33 skipped
- All pre-commit checks pass

## New Tests

- `test_empty_string_rejected_at_api_layer` - Verifies empty text is rejected at creation
- `test_legacy_empty_text_filtered_on_index` - Verifies legacy data is handled gracefully
- `test_whitespace_only_does_not_cause_error` - Verifies whitespace is accepted by OpenAI
- `test_valid_text_works` - Baseline test for valid text

