### PR TITLE
fix: correct Axion repository path for Java client release

### DIFF
--- a/agent-memory-client/agent-memory-client-java/build.gradle.kts
+++ b/agent-memory-client/agent-memory-client-java/build.gradle.kts
@@ -12,7 +12,8 @@ description = "Java client for the Agent Memory Server REST API"
 
 scmVersion {
     repository {
-        directory.set(project.rootProject.file("../..").canonicalPath)
+        // Navigate to the repository root (two levels up from the Java client directory)
+        directory.set(project.rootProject.projectDir.parentFile.parentFile.absolutePath)
     }
     tag {
         prefix.set("java-client-v")


### PR DESCRIPTION
Fix Java client release workflow by correcting the Axion Release Plugin repository path configuration. The plugin was unable to locate the git repository in CI, causing it to fall back to SNAPSHOT versions instead of using the specified release version.