### PR TITLE
fix: configure tag prefix for Java client release

### DIFF
--- a/.github/workflows/release-java-client.yml
+++ b/.github/workflows/release-java-client.yml
@@ -37,6 +37,7 @@ jobs:
       clone-to-dist-repo: false
       update-antora-version: false
       working-directory: 'agent-memory-client/agent-memory-client-java'
+      tag-prefix: 'java-client-v'
     secrets:
       git-access-token: ${{ secrets.GIT_ACCESS_TOKEN }}
       gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}

--- a/agent-memory-client/agent-memory-client-java/jreleaser.yml
+++ b/agent-memory-client/agent-memory-client-java/jreleaser.yml
@@ -21,6 +21,10 @@ release:
   github:
     owner: redis
     name: agent-memory-server
+    # Use the java-client-v prefix to match Axion's tag format
+    tagName: java-client-v{{projectVersion}}
+    releaseName: Java Client {{projectVersion}}
+    skipTag: true  # Tag is already created by Axion
     overwrite: true
     sign: true
     prerelease:


### PR DESCRIPTION
Fixes Java client release by aligning tag prefix configuration across Axion, JReleaser, and the shared workflow.

- Configure JReleaser with `tagName: java-client-v{{projectVersion}}` and `skipTag: true`
- Add `tag-prefix: 'java-client-v'` to workflow (requires redis/github-workflows update)