### PR TITLE
fix: add --git-root-search flag for JReleaser

### DIFF
--- a/.github/workflows/release-java-client.yml
+++ b/.github/workflows/release-java-client.yml
@@ -33,7 +33,7 @@ jobs:
       version: ${{ inputs.version }}
       version-increment: ${{ inputs.version-increment }}
       gradle-build-tasks: 'build test publish'
-      jreleaser-arguments: 'assemble'
+      jreleaser-arguments: 'assemble --git-root-search'
       clone-to-dist-repo: false
       update-antora-version: false
       working-directory: 'agent-memory-client/agent-memory-client-java'


### PR DESCRIPTION
Fixes JReleaser failing to find the git repository when running from the Java client subdirectory. Adds --git-root-search flag to JReleaser arguments so it searches parent directories for the .git folder.