### PR TITLE
Add CLI search and delete commands

### DIFF
--- a/agent_memory_server/cli.py
+++ b/agent_memory_server/cli.py
@@ -497,6 +497,340 @@ def task_worker(concurrency: int, redelivery_timeout: int):
     asyncio.run(_run_worker())
 
 
+@cli.command()
+@click.argument("query", default="")
+@click.option("--namespace", "-n", default=None, help="Filter by namespace")
+@click.option("--session-id", "-s", default=None, help="Filter by session ID")
+@click.option("--user-id", "-u", default=None, help="Filter by user ID")
+@click.option("--topics", "-t", default=None, help="Filter by topics (comma-separated)")
+@click.option(
+    "--entities", "-e", default=None, help="Filter by entities (comma-separated)"
+)
+@click.option("--limit", "-l", default=10, help="Maximum number of results")
+@click.option("--offset", "-o", default=0, help="Offset for pagination")
+@click.option(
+    "--distance-threshold",
+    "-d",
+    type=float,
+    default=None,
+    help="Maximum distance threshold for results",
+)
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["text", "json"]),
+    default="text",
+    show_default=True,
+    help="Output format",
+)
+def search(
+    query: str,
+    namespace: str | None,
+    session_id: str | None,
+    user_id: str | None,
+    topics: str | None,
+    entities: str | None,
+    limit: int,
+    offset: int,
+    distance_threshold: float | None,
+    output_format: str,
+):
+    """
+    Search long-term memories.
+
+    QUERY is the search text for semantic similarity matching.
+    If empty, lists all memories matching the filters.
+
+    Examples:
+
+        agent-memory search "What did we discuss about authentication?"
+
+        agent-memory search "project deadlines" --namespace myapp --limit 5
+
+        agent-memory search "user preferences" -u user123 --format json
+
+        agent-memory search --namespace myapp  # List all memories in namespace
+    """
+    import asyncio
+
+    from agent_memory_server.filters import (
+        Entities,
+        Namespace,
+        SessionId,
+        Topics,
+        UserId,
+    )
+    from agent_memory_server.long_term_memory import search_long_term_memories
+
+    configure_logging()
+
+    async def run_search():
+        # Build filter objects
+        namespace_filter = Namespace(eq=namespace) if namespace else None
+        session_filter = SessionId(eq=session_id) if session_id else None
+        user_filter = UserId(eq=user_id) if user_id else None
+        topics_filter = Topics(any=topics.split(",")) if topics else None
+        entities_filter = Entities(any=entities.split(",")) if entities else None
+
+        results = await search_long_term_memories(
+            text=query,
+            namespace=namespace_filter,
+            session_id=session_filter,
+            user_id=user_filter,
+            topics=topics_filter,
+            entities=entities_filter,
+            distance_threshold=distance_threshold,
+            limit=limit,
+            offset=offset,
+        )
+
+        if output_format == "json":
+            click.echo(results.model_dump_json(indent=2))
+        else:
+            click.echo(
+                f"Found {results.total} memories (showing {len(results.memories)}):"
+            )
+            click.echo("=" * 60)
+            for i, memory in enumerate(results.memories, 1):
+                click.echo(f"\n[{i}] ID: {memory.id}")
+                click.echo(f"    Distance: {memory.dist:.4f}")
+                if memory.namespace:
+                    click.echo(f"    Namespace: {memory.namespace}")
+                if memory.session_id:
+                    click.echo(f"    Session: {memory.session_id}")
+                if memory.user_id:
+                    click.echo(f"    User: {memory.user_id}")
+                if memory.topics:
+                    click.echo(f"    Topics: {', '.join(memory.topics)}")
+                if memory.entities:
+                    click.echo(f"    Entities: {', '.join(memory.entities)}")
+                click.echo(
+                    f"    Text: {memory.text[:200]}{'...' if len(memory.text) > 200 else ''}"
+                )
+            if results.next_offset:
+                click.echo(
+                    f"\nMore results available. Use --offset {results.next_offset} to continue."
+                )
+
+    asyncio.run(run_search())
+
+
+@cli.group()
+def delete():
+    """Delete memories or sessions."""
+    pass
+
+
+@delete.command("memory")
+@click.argument("target_ids", nargs=-1)
+@click.option(
+    "--empty-text",
+    is_flag=True,
+    help="Delete all memories with empty text",
+)
+@click.option(
+    "--invalid",
+    is_flag=True,
+    help="Delete memories with empty/invalid IDs (corrupted data)",
+)
+@click.option(
+    "--namespace", "-n", default=None, help="Filter by namespace (with --empty-text)"
+)
+@click.option(
+    "--user-id", "-u", default=None, help="Filter by user ID (with --empty-text)"
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help="Show what would be deleted without actually deleting",
+)
+@click.option(
+    "--force",
+    "-f",
+    is_flag=True,
+    help="Skip confirmation prompt",
+)
+def delete_memory_cmd(
+    target_ids: tuple[str, ...],
+    empty_text: bool,
+    invalid: bool,
+    namespace: str | None,
+    user_id: str | None,
+    dry_run: bool,
+    force: bool,
+):
+    """
+    Delete long-term memories by ID or criteria.
+
+    Examples:
+
+        agent-memory delete memory mem1 mem2 mem3
+
+        agent-memory delete memory --empty-text --dry-run
+
+        agent-memory delete memory --invalid -f
+
+        agent-memory delete memory --empty-text --namespace myapp -f
+    """
+    import asyncio
+
+    from agent_memory_server.filters import Namespace, UserId
+    from agent_memory_server.long_term_memory import (
+        delete_invalid_memories,
+        delete_long_term_memories,
+        search_long_term_memories,
+    )
+
+    configure_logging()
+
+    # Convert to list immediately
+    ids_list: list[str] = list(target_ids)
+
+    async def run_delete():
+        # Handle --invalid flag separately (deletes by Redis key, not by ID)
+        if invalid:
+            if dry_run:
+                click.echo(
+                    "Dry-run not supported for --invalid (requires Redis scan). "
+                    "Use without --dry-run to delete."
+                )
+                return
+
+            if not force:
+                click.confirm(
+                    "Delete all memories with invalid/empty IDs? This cannot be undone.",
+                    abort=True,
+                )
+
+            count = await delete_invalid_memories()
+            click.echo(f"Deleted {count} memories with invalid IDs.")
+            return
+
+        ids_to_delete: list[str] = ids_list.copy()
+
+        # If --empty-text flag, find all memories with empty text
+        if empty_text:
+            namespace_filter = Namespace(eq=namespace) if namespace else None
+            user_filter = UserId(eq=user_id) if user_id else None
+
+            # Search with empty query to list all, then filter for empty text
+            results = await search_long_term_memories(
+                text="",
+                namespace=namespace_filter,
+                user_id=user_filter,
+                limit=1000,  # Get a large batch
+            )
+
+            # Find memories with empty text
+            empty_text_memories = [
+                m for m in results.memories if not m.text or not m.text.strip()
+            ]
+
+            if not empty_text_memories:
+                click.echo("No memories with empty text found.")
+                return
+
+            # Separate valid IDs from invalid ones
+            valid_ids = [m.id for m in empty_text_memories if m.id and m.id.strip()]
+            invalid_count = len(empty_text_memories) - len(valid_ids)
+
+            click.echo(f"Found {len(empty_text_memories)} memories with empty text.")
+            if invalid_count > 0:
+                click.echo(
+                    f"Warning: {invalid_count} memories also have empty IDs. "
+                    f"Use --invalid flag to delete those."
+                )
+
+            if not valid_ids:
+                click.echo(
+                    "No deletable memories found (all have empty IDs). "
+                    "Use --invalid flag to delete those."
+                )
+                return
+
+            ids_to_delete.extend(valid_ids)
+
+        if not ids_to_delete:
+            click.echo("No memory IDs specified. Use --help for usage.")
+            return
+
+        # Remove duplicates while preserving order
+        ids_to_delete = list(dict.fromkeys(ids_to_delete))
+
+        if dry_run:
+            click.echo(f"Would delete {len(ids_to_delete)} memories:")
+            for mid in ids_to_delete[:20]:  # Show first 20
+                click.echo(f"  - {mid}")
+            if len(ids_to_delete) > 20:
+                click.echo(f"  ... and {len(ids_to_delete) - 20} more")
+            return
+
+        if not force:
+            click.confirm(
+                f"Delete {len(ids_to_delete)} memories? This cannot be undone.",
+                abort=True,
+            )
+
+        count = await delete_long_term_memories(ids=ids_to_delete)
+        click.echo(f"Deleted {count} memories.")
+
+    asyncio.run(run_delete())
+
+
+@delete.command("session")
+@click.argument("session_id", required=False)
+@click.option("--namespace", "-n", default=None, help="Namespace for the session")
+@click.option("--user-id", "-u", default=None, help="User ID for the session")
+@click.option(
+    "--force",
+    "-f",
+    is_flag=True,
+    help="Skip confirmation prompt",
+)
+def delete_session_cmd(
+    session_id: str | None,
+    namespace: str | None,
+    user_id: str | None,
+    force: bool,
+):
+    """
+    Delete a working memory session.
+
+    Examples:
+
+        agent-memory delete session my-session-123
+
+        agent-memory delete session my-session-123 --namespace myapp
+
+        agent-memory delete session my-session-123 -u user456 -f
+    """
+    import asyncio
+
+    from agent_memory_server.working_memory import delete_working_memory
+
+    configure_logging()
+
+    if not session_id:
+        click.echo("Session ID is required. Use --help for usage.")
+        return
+
+    async def run_delete():
+        if not force:
+            click.confirm(
+                f"Delete working memory session '{session_id}'? This cannot be undone.",
+                abort=True,
+            )
+
+        await delete_working_memory(
+            session_id=session_id,
+            user_id=user_id,
+            namespace=namespace,
+        )
+        click.echo(f"Deleted working memory session: {session_id}")
+
+    asyncio.run(run_delete())
+
+
 @cli.group()
 def token():
     """Manage authentication tokens."""
@@ -591,7 +925,7 @@ def add(
         click.echo("\nWARNING: Save this token securely. It will not be shown again.")
 
 
-@token.command()
+@token.command("list")
 @click.option(
     "--format",
     "output_format",
@@ -600,7 +934,7 @@ def add(
     show_default=True,
     help="Output format.",
 )
-def list(output_format: str):
+def list_tokens_cmd(output_format: str):
     """List all authentication tokens."""
     import asyncio
 

--- a/agent_memory_server/long_term_memory.py
+++ b/agent_memory_server/long_term_memory.py
@@ -1733,6 +1733,69 @@ async def delete_long_term_memories(
     return await adapter.delete_memories(ids)
 
 
+async def delete_invalid_memories(
+    redis_client: Redis | None = None,
+) -> int:
+    """
+    Delete corrupted memory records from Redis.
+
+    Corrupted records are those that:
+    1. Have empty key ID components (keys like "prefix:" or "prefix: ")
+    2. Are missing required fields (like 'text')
+
+    These records cannot be properly searched or deleted by ID, so they need
+    to be cleaned up directly via Redis key operations.
+
+    Args:
+        redis_client: Optional Redis client
+
+    Returns:
+        Number of memories deleted
+    """
+    if not redis_client:
+        redis_client = await get_redis_conn()
+
+    prefix = settings.redisvl_index_prefix
+
+    deleted_count = 0
+    cursor = 0
+
+    # Scan for all memory keys
+    while True:
+        cursor, keys = await redis_client.scan(
+            cursor=cursor, match=f"{prefix}:*", count=1000
+        )
+
+        for key in keys:
+            key_str = key.decode("utf-8") if isinstance(key, bytes) else key
+            should_delete = False
+
+            # Check 1: Empty ID in key name
+            id_part = key_str[len(prefix) + 1 :]  # +1 for the colon
+            if not id_part or not id_part.strip():
+                should_delete = True
+                logger.info(f"Found invalid memory with empty key ID: {key_str}")
+            else:
+                # Check 2: Missing required 'text' field
+                data = await redis_client.hgetall(key)
+                text_field = data.get(b"text") or data.get("text")
+                if text_field is None:
+                    should_delete = True
+                    logger.info(f"Found invalid memory missing 'text' field: {key_str}")
+
+            if should_delete:
+                await redis_client.delete(key)
+                deleted_count += 1
+
+        if cursor == 0:
+            break
+
+    if deleted_count > 0:
+        logger.info(f"Deleted {deleted_count} corrupted memory records")
+
+    return deleted_count
+
+
 async def get_long_term_memory_by_id(memory_id: str) -> MemoryRecord | None:
     """
     Get a single long-term memory by its ID.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,10 +11,13 @@ from agent_memory_server.cli import (
     VERSION,
     api,
     cli,
+    delete_memory_cmd,
+    delete_session_cmd,
     mcp,
     migrate_memories,
     rebuild_index,
     schedule_task,
+    search,
     task_worker,
     version,
 )
@@ -539,6 +542,777 @@ class TestTaskWorker:
         mock_worker_run.assert_called_once()
 
 
+class TestSearch:
+    """Tests for the search command."""
+
+    @patch("agent_memory_server.long_term_memory.search_long_term_memories")
+    def test_search_basic_query(self, mock_search):
+        """Test basic search with just a query."""
+        from agent_memory_server.models import MemoryRecordResult, MemoryRecordResults
+
+        mock_search.return_value = MemoryRecordResults(
+            memories=[
+                MemoryRecordResult(
+                    id="mem1",
+                    text="Test memory about authentication",
+                    dist=0.15,
+                    namespace="default",
+                )
+            ],
+            total=1,
+            next_offset=None,
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(search, ["test query"])
+
+        assert result.exit_code == 0
+        assert "Found 1 memories" in result.output
+        assert "mem1" in result.output
+        assert "Test memory about authentication" in result.output
+        assert "0.1500" in result.output
+        mock_search.assert_called_once()
+
+    @patch("agent_memory_server.long_term_memory.search_long_term_memories")
+    def test_search_with_namespace_filter(self, mock_search):
+        """Test search with namespace filter."""
+        from agent_memory_server.models import MemoryRecordResults
+
+        mock_search.return_value = MemoryRecordResults(
+            memories=[],
+            total=0,
+            next_offset=None,
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(search, ["test query", "--namespace", "myapp"])
+
+        assert result.exit_code == 0
+        mock_search.assert_called_once()
+        call_kwargs = mock_search.call_args[1]
+        assert call_kwargs["namespace"].eq == "myapp"
+
+    @patch("agent_memory_server.long_term_memory.search_long_term_memories")
+    def test_search_with_session_id_filter(self, mock_search):
+        """Test search with session ID filter."""
+        from agent_memory_server.models import MemoryRecordResults
+
+        mock_search.return_value = MemoryRecordResults(
+            memories=[],
+            total=0,
+            next_offset=None,
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(search, ["test query", "-s", "session123"])
+
+        assert result.exit_code == 0
+        call_kwargs = mock_search.call_args[1]
+        assert call_kwargs["session_id"].eq == "session123"
+
+    @patch("agent_memory_server.long_term_memory.search_long_term_memories")
+    def test_search_with_user_id_filter(self, mock_search):
+        """Test search with user ID filter."""
+        from agent_memory_server.models import MemoryRecordResults
+
+        mock_search.return_value = MemoryRecordResults(
+            memories=[],
+            total=0,
+            next_offset=None,
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(search, ["test query", "-u", "user456"])
+
+        assert result.exit_code == 0
+        call_kwargs = mock_search.call_args[1]
+        assert call_kwargs["user_id"].eq == "user456"
+
+    @patch("agent_memory_server.long_term_memory.search_long_term_memories")
+    def test_search_with_topics_filter(self, mock_search):
+        """Test search with topics filter (comma-separated)."""
+        from agent_memory_server.models import MemoryRecordResults
+
+        mock_search.return_value = MemoryRecordResults(
+            memories=[],
+            total=0,
+            next_offset=None,
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(search, ["test query", "-t", "auth,security"])
+
+        assert result.exit_code == 0
+        call_kwargs = mock_search.call_args[1]
+        assert call_kwargs["topics"].any == ["auth", "security"]
+
+    @patch("agent_memory_server.long_term_memory.search_long_term_memories")
+    def test_search_with_entities_filter(self, mock_search):
+        """Test search with entities filter (comma-separated)."""
+        from agent_memory_server.models import MemoryRecordResults
+
+        mock_search.return_value = MemoryRecordResults(
+            memories=[],
+            total=0,
+            next_offset=None,
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(search, ["test query", "-e", "User,Project"])
+
+        assert result.exit_code == 0
+        call_kwargs = mock_search.call_args[1]
+        assert call_kwargs["entities"].any == ["User", "Project"]
+
+    @patch("agent_memory_server.long_term_memory.search_long_term_memories")
+    def test_search_with_limit_and_offset(self, mock_search):
+        """Test search with limit and offset pagination."""
+        from agent_memory_server.models import MemoryRecordResults
+
+        mock_search.return_value = MemoryRecordResults(
+            memories=[],
+            total=0,
+            next_offset=None,
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(search, ["test query", "-l", "5", "-o", "10"])
+
+        assert result.exit_code == 0
+        call_kwargs = mock_search.call_args[1]
+        assert call_kwargs["limit"] == 5
+        assert call_kwargs["offset"] == 10
+
+    @patch("agent_memory_server.long_term_memory.search_long_term_memories")
+    def test_search_with_distance_threshold(self, mock_search):
+        """Test search with distance threshold."""
+        from agent_memory_server.models import MemoryRecordResults
+
+        mock_search.return_value = MemoryRecordResults(
+            memories=[],
+            total=0,
+            next_offset=None,
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(search, ["test query", "-d", "0.5"])
+
+        assert result.exit_code == 0
+        call_kwargs = mock_search.call_args[1]
+        assert call_kwargs["distance_threshold"] == 0.5
+
+    @patch("agent_memory_server.long_term_memory.search_long_term_memories")
+    def test_search_json_output(self, mock_search):
+        """Test search with JSON output format."""
+        from agent_memory_server.models import MemoryRecordResult, MemoryRecordResults
+
+        mock_search.return_value = MemoryRecordResults(
+            memories=[
+                MemoryRecordResult(
+                    id="mem1",
+                    text="Test memory",
+                    dist=0.1,
+                    namespace="default",
+                    topics=["topic1"],
+                    entities=["entity1"],
+                )
+            ],
+            total=1,
+            next_offset=None,
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(search, ["test query", "--format", "json"])
+
+        assert result.exit_code == 0
+        # Verify it's valid JSON
+        import json
+
+        output = json.loads(result.output)
+        assert output["total"] == 1
+        assert len(output["memories"]) == 1
+        assert output["memories"][0]["id"] == "mem1"
+
+    @patch("agent_memory_server.long_term_memory.search_long_term_memories")
+    def test_search_text_output_with_all_fields(self, mock_search):
+        """Test text output displays all memory fields."""
+        from agent_memory_server.models import MemoryRecordResult, MemoryRecordResults
+
+        mock_search.return_value = MemoryRecordResults(
+            memories=[
+                MemoryRecordResult(
+                    id="mem1",
+                    text="Test memory content",
+                    dist=0.25,
+                    namespace="myapp",
+                    session_id="sess123",
+                    user_id="user456",
+                    topics=["topic1", "topic2"],
+                    entities=["Entity1", "Entity2"],
+                )
+            ],
+            total=1,
+            next_offset=None,
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(search, ["test query"])
+
+        assert result.exit_code == 0
+        assert "mem1" in result.output
+        assert "0.2500" in result.output
+        assert "myapp" in result.output
+        assert "sess123" in result.output
+        assert "user456" in result.output
+        assert "topic1, topic2" in result.output
+        assert "Entity1, Entity2" in result.output
+        assert "Test memory content" in result.output
+
+    @patch("agent_memory_server.long_term_memory.search_long_term_memories")
+    def test_search_text_truncation(self, mock_search):
+        """Test that long text is truncated in text output."""
+        from agent_memory_server.models import MemoryRecordResult, MemoryRecordResults
+
+        long_text = "A" * 300  # 300 characters
+        mock_search.return_value = MemoryRecordResults(
+            memories=[
+                MemoryRecordResult(
+                    id="mem1",
+                    text=long_text,
+                    dist=0.1,
+                )
+            ],
+            total=1,
+            next_offset=None,
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(search, ["test query"])
+
+        assert result.exit_code == 0
+        # Should show first 200 chars + "..."
+        assert "A" * 200 in result.output
+        assert "..." in result.output
+
+    @patch("agent_memory_server.long_term_memory.search_long_term_memories")
+    def test_search_pagination_hint(self, mock_search):
+        """Test that pagination hint is shown when more results available."""
+        from agent_memory_server.models import MemoryRecordResult, MemoryRecordResults
+
+        mock_search.return_value = MemoryRecordResults(
+            memories=[
+                MemoryRecordResult(
+                    id="mem1",
+                    text="Test memory",
+                    dist=0.1,
+                )
+            ],
+            total=15,
+            next_offset=10,
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(search, ["test query"])
+
+        assert result.exit_code == 0
+        assert "More results available" in result.output
+        assert "--offset 10" in result.output
+
+    @patch("agent_memory_server.long_term_memory.search_long_term_memories")
+    def test_search_no_results(self, mock_search):
+        """Test search with no results."""
+        from agent_memory_server.models import MemoryRecordResults
+
+        mock_search.return_value = MemoryRecordResults(
+            memories=[],
+            total=0,
+            next_offset=None,
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(search, ["test query"])
+
+        assert result.exit_code == 0
+        assert "Found 0 memories" in result.output
+
+    @patch("agent_memory_server.long_term_memory.search_long_term_memories")
+    def test_search_multiple_results(self, mock_search):
+        """Test search with multiple results."""
+        from agent_memory_server.models import MemoryRecordResult, MemoryRecordResults
+
+        mock_search.return_value = MemoryRecordResults(
+            memories=[
+                MemoryRecordResult(id="mem1", text="First memory", dist=0.1),
+                MemoryRecordResult(id="mem2", text="Second memory", dist=0.2),
+                MemoryRecordResult(id="mem3", text="Third memory", dist=0.3),
+            ],
+            total=3,
+            next_offset=None,
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(search, ["test query"])
+
+        assert result.exit_code == 0
+        assert "Found 3 memories" in result.output
+        assert "[1]" in result.output
+        assert "[2]" in result.output
+        assert "[3]" in result.output
+        assert "mem1" in result.output
+        assert "mem2" in result.output
+        assert "mem3" in result.output
+
+    @patch("agent_memory_server.long_term_memory.search_long_term_memories")
+    def test_search_all_filters_combined(self, mock_search):
+        """Test search with all filters combined."""
+        from agent_memory_server.models import MemoryRecordResults
+
+        mock_search.return_value = MemoryRecordResults(
+            memories=[],
+            total=0,
+            next_offset=None,
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            search,
+            [
+                "test query",
+                "--namespace",
+                "myapp",
+                "--session-id",
+                "sess123",
+                "--user-id",
+                "user456",
+                "--topics",
+                "auth,security",
+                "--entities",
+                "User,Admin",
+                "--limit",
+                "20",
+                "--offset",
+                "5",
+                "--distance-threshold",
+                "0.3",
+            ],
+        )
+
+        assert result.exit_code == 0
+        call_kwargs = mock_search.call_args[1]
+        assert call_kwargs["text"] == "test query"
+        assert call_kwargs["namespace"].eq == "myapp"
+        assert call_kwargs["session_id"].eq == "sess123"
+        assert call_kwargs["user_id"].eq == "user456"
+        assert call_kwargs["topics"].any == ["auth", "security"]
+        assert call_kwargs["entities"].any == ["User", "Admin"]
+        assert call_kwargs["limit"] == 20
+        assert call_kwargs["offset"] == 5
+        assert call_kwargs["distance_threshold"] == 0.3
+
+    def test_search_help(self):
+        """Test search command help output."""
+        runner = CliRunner()
+        result = runner.invoke(search, ["--help"])
+
+        assert result.exit_code == 0
+        assert "Search long-term memories" in result.output
+        assert "--namespace" in result.output
+        assert "--session-id" in result.output
+        assert "--user-id" in result.output
+        assert "--topics" in result.output
+        assert "--entities" in result.output
+        assert "--limit" in result.output
+        assert "--offset" in result.output
+        assert "--distance-threshold" in result.output
+        assert "--format" in result.output
+
+    @patch("agent_memory_server.long_term_memory.search_long_term_memories")
+    def test_search_empty_query_lists_all(self, mock_search):
+        """Test search with empty query lists all memories matching filters."""
+        from agent_memory_server.models import MemoryRecordResult, MemoryRecordResults
+
+        mock_search.return_value = MemoryRecordResults(
+            memories=[
+                MemoryRecordResult(id="mem1", text="Memory 1", dist=0.0),
+                MemoryRecordResult(id="mem2", text="Memory 2", dist=0.0),
+            ],
+            total=2,
+            next_offset=None,
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(search, ["--namespace", "myapp"])
+
+        assert result.exit_code == 0
+        assert "Found 2 memories" in result.output
+        mock_search.assert_called_once()
+        call_kwargs = mock_search.call_args[1]
+        assert call_kwargs["text"] == ""
+        assert call_kwargs["namespace"].eq == "myapp"
+
+    @patch("agent_memory_server.long_term_memory.search_long_term_memories")
+    def test_search_no_args_lists_all(self, mock_search):
+        """Test search with no arguments lists all memories."""
+        from agent_memory_server.models import MemoryRecordResults
+
+        mock_search.return_value = MemoryRecordResults(
+            memories=[],
+            total=0,
+            next_offset=None,
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(search, [])
+
+        assert result.exit_code == 0
+        mock_search.assert_called_once()
+        call_kwargs = mock_search.call_args[1]
+        assert call_kwargs["text"] == ""
+
+
+class TestDeleteMemory:
+    """Tests for the delete memory command."""
+
+    @patch("agent_memory_server.long_term_memory.delete_long_term_memories")
+    def test_delete_by_ids(self, mock_delete):
+        """Test deleting memories by explicit IDs."""
+        mock_delete.return_value = 3
+
+        runner = CliRunner()
+        result = runner.invoke(delete_memory_cmd, ["mem1", "mem2", "mem3", "-f"])
+
+        assert result.exit_code == 0
+        assert "Deleted 3 memories" in result.output
+        mock_delete.assert_called_once_with(ids=["mem1", "mem2", "mem3"])
+
+    @patch("agent_memory_server.long_term_memory.delete_long_term_memories")
+    def test_delete_dry_run(self, mock_delete):
+        """Test delete with dry-run flag."""
+        runner = CliRunner()
+        result = runner.invoke(delete_memory_cmd, ["mem1", "mem2", "--dry-run"])
+
+        assert result.exit_code == 0
+        assert "Would delete 2 memories" in result.output
+        assert "mem1" in result.output
+        assert "mem2" in result.output
+        mock_delete.assert_not_called()
+
+    @patch("agent_memory_server.long_term_memory.delete_long_term_memories")
+    def test_delete_requires_confirmation(self, mock_delete):
+        """Test that delete requires confirmation without -f flag."""
+        runner = CliRunner()
+        result = runner.invoke(delete_memory_cmd, ["mem1"], input="n\n")
+
+        assert result.exit_code == 1  # Aborted
+        mock_delete.assert_not_called()
+
+    @patch("agent_memory_server.long_term_memory.delete_long_term_memories")
+    def test_delete_with_confirmation(self, mock_delete):
+        """Test delete with user confirmation."""
+        mock_delete.return_value = 1
+
+        runner = CliRunner()
+        result = runner.invoke(delete_memory_cmd, ["mem1"], input="y\n")
+
+        assert result.exit_code == 0
+        assert "Deleted 1 memories" in result.output
+        mock_delete.assert_called_once()
+
+    @patch("agent_memory_server.long_term_memory.delete_long_term_memories")
+    @patch("agent_memory_server.long_term_memory.search_long_term_memories")
+    def test_delete_empty_text_memories(self, mock_search, mock_delete):
+        """Test deleting memories with empty text."""
+        from agent_memory_server.models import MemoryRecordResult, MemoryRecordResults
+
+        mock_search.return_value = MemoryRecordResults(
+            memories=[
+                MemoryRecordResult(id="empty1", text="", dist=0.0),
+                MemoryRecordResult(id="empty2", text="   ", dist=0.0),
+                MemoryRecordResult(id="valid", text="Has content", dist=0.0),
+            ],
+            total=3,
+            next_offset=None,
+        )
+        mock_delete.return_value = 2
+
+        runner = CliRunner()
+        result = runner.invoke(delete_memory_cmd, ["--empty-text", "-f"])
+
+        assert result.exit_code == 0
+        assert "Found 2 memories with empty text" in result.output
+        assert "Deleted 2 memories" in result.output
+        mock_delete.assert_called_once_with(ids=["empty1", "empty2"])
+
+    @patch("agent_memory_server.long_term_memory.search_long_term_memories")
+    def test_delete_empty_text_none_found(self, mock_search):
+        """Test --empty-text when no empty memories exist."""
+        from agent_memory_server.models import MemoryRecordResult, MemoryRecordResults
+
+        mock_search.return_value = MemoryRecordResults(
+            memories=[
+                MemoryRecordResult(id="valid", text="Has content", dist=0.0),
+            ],
+            total=1,
+            next_offset=None,
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(delete_memory_cmd, ["--empty-text"])
+
+        assert result.exit_code == 0
+        assert "No memories with empty text found" in result.output
+
+    @patch("agent_memory_server.long_term_memory.delete_long_term_memories")
+    @patch("agent_memory_server.long_term_memory.search_long_term_memories")
+    def test_delete_empty_text_with_namespace_filter(self, mock_search, mock_delete):
+        """Test --empty-text with namespace filter."""
+        from agent_memory_server.models import MemoryRecordResult, MemoryRecordResults
+
+        mock_search.return_value = MemoryRecordResults(
+            memories=[
+                MemoryRecordResult(id="empty1", text="", dist=0.0, namespace="myapp"),
+            ],
+            total=1,
+            next_offset=None,
+        )
+        mock_delete.return_value = 1
+
+        runner = CliRunner()
+        result = runner.invoke(
+            delete_memory_cmd, ["--empty-text", "--namespace", "myapp", "-f"]
+        )
+
+        assert result.exit_code == 0
+        mock_search.assert_called_once()
+        call_kwargs = mock_search.call_args[1]
+        assert call_kwargs["namespace"].eq == "myapp"
+
+    @patch("agent_memory_server.long_term_memory.delete_long_term_memories")
+    @patch("agent_memory_server.long_term_memory.search_long_term_memories")
+    def test_delete_empty_text_dry_run(self, mock_search, mock_delete):
+        """Test --empty-text with --dry-run."""
+        from agent_memory_server.models import MemoryRecordResult, MemoryRecordResults
+
+        mock_search.return_value = MemoryRecordResults(
+            memories=[
+                MemoryRecordResult(id="empty1", text="", dist=0.0),
+                MemoryRecordResult(id="empty2", text="", dist=0.0),
+            ],
+            total=2,
+            next_offset=None,
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(delete_memory_cmd, ["--empty-text", "--dry-run"])
+
+        assert result.exit_code == 0
+        assert "Would delete 2 memories" in result.output
+        mock_delete.assert_not_called()
+
+    @patch("agent_memory_server.long_term_memory.search_long_term_memories")
+    def test_delete_empty_text_with_empty_ids(self, mock_search):
+        """Test --empty-text when some memories have empty IDs."""
+        from agent_memory_server.models import MemoryRecordResult, MemoryRecordResults
+
+        mock_search.return_value = MemoryRecordResults(
+            memories=[
+                MemoryRecordResult(id="", text="", dist=0.0),
+                MemoryRecordResult(id="", text="", dist=0.0),
+                MemoryRecordResult(id="   ", text="", dist=0.0),
+            ],
+            total=3,
+            next_offset=None,
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(delete_memory_cmd, ["--empty-text", "--dry-run"])
+
+        assert result.exit_code == 0
+        assert "Found 3 memories with empty text" in result.output
+        assert "3 memories also have empty IDs" in result.output
+        # Updated message to match new CLI output
+        assert "Use --invalid flag" in result.output
+
+    @patch("agent_memory_server.long_term_memory.delete_long_term_memories")
+    @patch("agent_memory_server.long_term_memory.search_long_term_memories")
+    def test_delete_empty_text_mixed_ids(self, mock_search, mock_delete):
+        """Test --empty-text with mix of valid and empty IDs."""
+        from agent_memory_server.models import MemoryRecordResult, MemoryRecordResults
+
+        mock_search.return_value = MemoryRecordResults(
+            memories=[
+                MemoryRecordResult(id="valid1", text="", dist=0.0),
+                MemoryRecordResult(id="", text="", dist=0.0),
+                MemoryRecordResult(id="valid2", text="   ", dist=0.0),
+            ],
+            total=3,
+            next_offset=None,
+        )
+        mock_delete.return_value = 2
+
+        runner = CliRunner()
+        result = runner.invoke(delete_memory_cmd, ["--empty-text", "-f"])
+
+        assert result.exit_code == 0
+        assert "Found 3 memories with empty text" in result.output
+        assert "1 memories also have empty IDs" in result.output
+        assert "Deleted 2 memories" in result.output
+        mock_delete.assert_called_once_with(ids=["valid1", "valid2"])
+
+    @patch("agent_memory_server.long_term_memory.delete_invalid_memories")
+    def test_delete_invalid_memories(self, mock_delete_invalid):
+        """Test --invalid flag to delete memories with empty IDs."""
+        mock_delete_invalid.return_value = 5
+
+        runner = CliRunner()
+        result = runner.invoke(delete_memory_cmd, ["--invalid", "-f"])
+
+        assert result.exit_code == 0
+        assert "Deleted 5 memories with invalid IDs" in result.output
+        mock_delete_invalid.assert_called_once()
+
+    @patch("agent_memory_server.long_term_memory.delete_invalid_memories")
+    def test_delete_invalid_requires_confirmation(self, mock_delete_invalid):
+        """Test --invalid requires confirmation."""
+        runner = CliRunner()
+        result = runner.invoke(delete_memory_cmd, ["--invalid"], input="n\n")
+
+        assert result.exit_code == 1  # Aborted
+        mock_delete_invalid.assert_not_called()
+
+    def test_delete_invalid_dry_run_not_supported(self):
+        """Test --invalid with --dry-run shows message."""
+        runner = CliRunner()
+        result = runner.invoke(delete_memory_cmd, ["--invalid", "--dry-run"])
+
+        assert result.exit_code == 0
+        assert "Dry-run not supported for --invalid" in result.output
+
+    def test_delete_no_ids_specified(self):
+        """Test delete with no IDs and no flags."""
+        runner = CliRunner()
+        result = runner.invoke(delete_memory_cmd, [])
+
+        assert result.exit_code == 0
+        assert "No memory IDs specified" in result.output
+
+    @patch("agent_memory_server.long_term_memory.delete_long_term_memories")
+    def test_delete_dry_run_truncates_long_list(self, mock_delete):
+        """Test dry-run truncates list when more than 20 IDs."""
+        # Generate 25 IDs to trigger truncation
+        ids = [f"mem{i}" for i in range(25)]
+
+        runner = CliRunner()
+        result = runner.invoke(delete_memory_cmd, ids + ["--dry-run"])
+
+        assert result.exit_code == 0
+        assert "Would delete 25 memories" in result.output
+        assert "mem0" in result.output
+        assert "mem19" in result.output
+        assert "... and 5 more" in result.output
+        mock_delete.assert_not_called()
+
+    def test_delete_help(self):
+        """Test delete memory command help output."""
+        runner = CliRunner()
+        result = runner.invoke(delete_memory_cmd, ["--help"])
+
+        assert result.exit_code == 0
+        assert "Delete long-term memories" in result.output
+        assert "--empty-text" in result.output
+        assert "--invalid" in result.output
+        assert "--dry-run" in result.output
+        assert "--force" in result.output
+        assert "--namespace" in result.output
+        assert "--user-id" in result.output
+
+
+class TestDeleteSession:
+    """Tests for the delete session command."""
+
+    @patch("agent_memory_server.working_memory.delete_working_memory")
+    def test_delete_session_by_id(self, mock_delete):
+        """Test deleting a session by ID."""
+        runner = CliRunner()
+        result = runner.invoke(delete_session_cmd, ["my-session-123", "-f"])
+
+        assert result.exit_code == 0
+        assert "Deleted working memory session: my-session-123" in result.output
+        mock_delete.assert_called_once_with(
+            session_id="my-session-123",
+            user_id=None,
+            namespace=None,
+        )
+
+    @patch("agent_memory_server.working_memory.delete_working_memory")
+    def test_delete_session_with_namespace(self, mock_delete):
+        """Test deleting a session with namespace."""
+        runner = CliRunner()
+        result = runner.invoke(
+            delete_session_cmd, ["my-session-123", "--namespace", "myapp", "-f"]
+        )
+
+        assert result.exit_code == 0
+        mock_delete.assert_called_once_with(
+            session_id="my-session-123",
+            user_id=None,
+            namespace="myapp",
+        )
+
+    @patch("agent_memory_server.working_memory.delete_working_memory")
+    def test_delete_session_with_user_id(self, mock_delete):
+        """Test deleting a session with user ID."""
+        runner = CliRunner()
+        result = runner.invoke(
+            delete_session_cmd, ["my-session-123", "-u", "user456", "-f"]
+        )
+
+        assert result.exit_code == 0
+        mock_delete.assert_called_once_with(
+            session_id="my-session-123",
+            user_id="user456",
+            namespace=None,
+        )
+
+    @patch("agent_memory_server.working_memory.delete_working_memory")
+    def test_delete_session_requires_confirmation(self, mock_delete):
+        """Test that delete session requires confirmation."""
+        runner = CliRunner()
+        result = runner.invoke(delete_session_cmd, ["my-session-123"], input="n\n")
+
+        assert result.exit_code == 1  # Aborted
+        mock_delete.assert_not_called()
+
+    @patch("agent_memory_server.working_memory.delete_working_memory")
+    def test_delete_session_with_confirmation(self, mock_delete):
+        """Test delete session with user confirmation."""
+        runner = CliRunner()
+        result = runner.invoke(delete_session_cmd, ["my-session-123"], input="y\n")
+
+        assert result.exit_code == 0
+        assert "Deleted working memory session" in result.output
+        mock_delete.assert_called_once()
+
+    def test_delete_session_no_id(self):
+        """Test delete session without session ID."""
+        runner = CliRunner()
+        result = runner.invoke(delete_session_cmd, [])
+
+        assert result.exit_code == 0
+        assert "Session ID is required" in result.output
+
+    def test_delete_session_help(self):
+        """Test delete session command help output."""
+        runner = CliRunner()
+        result = runner.invoke(delete_session_cmd, ["--help"])
+
+        assert result.exit_code == 0
+        assert "Delete a working memory session" in result.output
+        assert "--namespace" in result.output
+        assert "--user-id" in result.output
+        assert "--force" in result.output
+
+
 class TestCliGroup:
     """Tests for the main CLI group."""
 
@@ -562,6 +1336,8 @@ class TestCliGroup:
             "api",
             "mcp",
             "schedule-task",
+            "search",
+            "delete",
             "task-worker",
         ]
         for command in expected_commands:

--- a/tests/test_long_term_memory.py
+++ b/tests/test_long_term_memory.py
@@ -10,6 +10,7 @@ from agent_memory_server.long_term_memory import (
     count_long_term_memories,
     deduplicate_by_hash,
     deduplicate_by_id,
+    delete_invalid_memories,
     delete_long_term_memories,
     extract_memory_structure,
     index_long_term_memories,
@@ -1154,3 +1155,130 @@ class TestSearchQueryOptimization:
         assert call_kwargs["limit"] == 20
         assert call_kwargs["offset"] == 10
         assert call_kwargs["distance_threshold"] == 0.3
+
+
+class TestDeleteInvalidMemories:
+    """Tests for the delete_invalid_memories function."""
+
+    @pytest.mark.asyncio
+    async def test_delete_invalid_memories_empty_ids(self, mock_async_redis_client):
+        """Test deleting memories with empty key IDs."""
+
+        # Mock scan to return keys with empty ID components
+        async def mock_scan(cursor, match, count):
+            return (0, [b"memory:", b"memory: ", b"memory:valid-id"])
+
+        mock_async_redis_client.scan = AsyncMock(side_effect=mock_scan)
+        mock_async_redis_client.delete = AsyncMock(return_value=1)
+        # Valid key has text field
+        mock_async_redis_client.hgetall = AsyncMock(return_value={b"text": b"content"})
+
+        with (
+            patch(
+                "agent_memory_server.long_term_memory.get_redis_conn",
+                return_value=mock_async_redis_client,
+            ),
+            patch("agent_memory_server.long_term_memory.settings") as mock_settings,
+        ):
+            mock_settings.redisvl_index_prefix = "memory"
+
+            count = await delete_invalid_memories()
+
+        # Should delete "memory:" and "memory: " but not "memory:valid-id"
+        assert count == 2
+        assert mock_async_redis_client.delete.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_delete_invalid_memories_missing_text_field(
+        self, mock_async_redis_client
+    ):
+        """Test deleting memories missing the text field."""
+
+        async def mock_scan(cursor, match, count):
+            return (0, [b"memory:id1", b"memory:id2", b"memory:id3"])
+
+        # id1 and id2 missing text field, id3 has it
+        async def mock_hgetall(key):
+            key_str = key.decode() if isinstance(key, bytes) else key
+            if key_str == "memory:id3":
+                return {b"text": b"valid content", b"topics": b"test"}
+            return {b"topics": b"test"}  # Missing text field
+
+        mock_async_redis_client.scan = AsyncMock(side_effect=mock_scan)
+        mock_async_redis_client.hgetall = AsyncMock(side_effect=mock_hgetall)
+        mock_async_redis_client.delete = AsyncMock(return_value=1)
+
+        with (
+            patch(
+                "agent_memory_server.long_term_memory.get_redis_conn",
+                return_value=mock_async_redis_client,
+            ),
+            patch("agent_memory_server.long_term_memory.settings") as mock_settings,
+        ):
+            mock_settings.redisvl_index_prefix = "memory"
+
+            count = await delete_invalid_memories()
+
+        # Should delete id1 and id2 (missing text), keep id3
+        assert count == 2
+        assert mock_async_redis_client.delete.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_delete_invalid_memories_none_found(self, mock_async_redis_client):
+        """Test when no invalid memories exist."""
+
+        # Mock scan to return only valid keys
+        async def mock_scan(cursor, match, count):
+            return (0, [b"memory:id1", b"memory:id2"])
+
+        mock_async_redis_client.scan = AsyncMock(side_effect=mock_scan)
+        mock_async_redis_client.delete = AsyncMock(return_value=1)
+        # All keys have text field
+        mock_async_redis_client.hgetall = AsyncMock(return_value={b"text": b"content"})
+
+        with (
+            patch(
+                "agent_memory_server.long_term_memory.get_redis_conn",
+                return_value=mock_async_redis_client,
+            ),
+            patch("agent_memory_server.long_term_memory.settings") as mock_settings,
+        ):
+            mock_settings.redisvl_index_prefix = "memory"
+
+            count = await delete_invalid_memories()
+
+        assert count == 0
+        mock_async_redis_client.delete.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_delete_invalid_memories_pagination(self, mock_async_redis_client):
+        """Test scan pagination when there are many keys."""
+        scan_call_count = 0
+
+        # Mock scan to return cursor indicating more results
+        async def mock_scan(cursor, match, count):
+            nonlocal scan_call_count
+            scan_call_count += 1
+            if scan_call_count == 1:
+                return (100, [b"memory:", b"memory:valid1"])  # More to come
+            return (0, [b"memory: ", b"memory:valid2"])  # Last batch
+
+        mock_async_redis_client.scan = AsyncMock(side_effect=mock_scan)
+        mock_async_redis_client.delete = AsyncMock(return_value=1)
+        # Valid keys have text field
+        mock_async_redis_client.hgetall = AsyncMock(return_value={b"text": b"content"})
+
+        with (
+            patch(
+                "agent_memory_server.long_term_memory.get_redis_conn",
+                return_value=mock_async_redis_client,
+            ),
+            patch("agent_memory_server.long_term_memory.settings") as mock_settings,
+        ):
+            mock_settings.redisvl_index_prefix = "memory"
+
+            count = await delete_invalid_memories()
+
+        # Should delete "memory:" from first batch and "memory: " from second batch
+        assert count == 2
+        assert mock_async_redis_client.scan.call_count == 2


### PR DESCRIPTION
## Summary

Adds CLI commands for searching and deleting long-term memories, plus supporting functions.

## New CLI Commands

### `agent-memory search`
Search long-term memories with semantic similarity and filters:
```bash
agent-memory search "What did we discuss about authentication?"
agent-memory search "project deadlines" --namespace myapp --limit 5
agent-memory search --namespace myapp  # List all memories in namespace
agent-memory search -u user123 --format json
```

### `agent-memory delete`
Delete memories by ID with confirmation prompts:
```bash
agent-memory delete --ids mem1,mem2,mem3
agent-memory delete --ids mem1 --yes  # Skip confirmation
agent-memory delete --ids mem1 --dry-run  # Preview only
agent-memory delete --empty-text  # Delete memories with empty text
agent-memory delete --invalid  # Delete malformed memories
```

### `agent-memory delete-session`
Delete working memory sessions:
```bash
agent-memory delete-session --id session123
agent-memory delete-session --id session123 --namespace myapp
```

## Changes

- `cli.py`: Added `search`, `delete`, and `delete-session` commands
- `long_term_memory.py`: Added `delete_invalid_memories()` and `find_memories_with_empty_text()` functions
- Full test coverage for new CLI commands and functions
