### PR TITLE
fix(docs): escape pipe and bracket characters in api.md tables

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -674,7 +674,7 @@ Generic acknowledgement response
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `status` | string \| Yes |  |
+| `status` | string | Yes |  |
 
 ### SessionListResponse
 


### PR DESCRIPTION
## Summary

Escape `|` and `[` characters inside markdown table cells in `docs/api.md` so they render correctly as union types (`string \| null`) and generic types (`array\[string]`) instead of being interpreted as table column separators.

Based on #148 by @dobesv, rebased onto main with additional fixes for instances that were added to the file after the original PR was created.

Closes #148

## Test plan
- [ ] `mkdocs serve` renders the API docs tables correctly
- [ ] All union types (`string | null`, `object | null`, etc.) display as intended
- [ ] All generic types (`array[string]`, `array[MemoryMessage]`, etc.) display correctly