### PR TITLE
chore: add changelog path filtering for Java client releases

### DIFF
--- a/.github/workflows/release-java-client.yml
+++ b/.github/workflows/release-java-client.yml
@@ -36,6 +36,7 @@ jobs:
       jreleaser-arguments: 'assemble --git-root-search'
       clone-to-dist-repo: false
       update-antora-version: false
+      jreleaser-version: 'early-access'
       working-directory: 'agent-memory-client/agent-memory-client-java'
       tag-prefix: 'java-client-v'
       git-root-search: true

--- a/agent-memory-client/agent-memory-client-java/jreleaser.yml
+++ b/agent-memory-client/agent-memory-client-java/jreleaser.yml
@@ -33,6 +33,8 @@ release:
     changelog:
       formatted: ALWAYS
       preset: conventional-commits
+      paths:
+        - 'agent-memory-client/agent-memory-client-java/'
       includeLabels:
         - 'feat'
         - 'feature'


### PR DESCRIPTION
## Summary
- Adds `changelog.paths` filter to `jreleaser.yml` so Java client release changelogs only include commits affecting `agent-memory-client/agent-memory-client-java/`, instead of all commits in the monorepo
- Pins `jreleaser-version` to `early-access` in the release workflow since the `paths` feature ([jreleaser/jreleaser#2073](https://github.com/jreleaser/jreleaser/pull/2073), merged Feb 21) is not yet in a stable JReleaser release (latest stable is v1.22.0)

## Test plan
- [ ] Trigger a dry-run of the Java client release workflow to verify changelog filtering works
- [ ] Once JReleaser publishes a stable release with this feature, update `jreleaser-version` back to `latest`

Closes #154

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: release automation/config-only changes; main impact is potentially altering the generated GitHub release notes and relying on an early-access JReleaser build.
> 
> **Overview**
> Java client releases now generate changelogs filtered to commits that touch `agent-memory-client/agent-memory-client-java/` via `release.github.changelog.paths` in `jreleaser.yml`, avoiding monorepo-wide noise.
> 
> The `release-java-client` workflow pins `jreleaser-version` to `early-access` so the release job can use this changelog path-filtering capability.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dda303d964662d6e9cff8e07ab5f828392ba00ef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->