### PR TITLE
fix: Enable deduplication for trailing extraction indexing

### DIFF
--- a/agent_memory_server/long_term_memory.py
+++ b/agent_memory_server/long_term_memory.py
@@ -393,7 +393,10 @@ async def run_delayed_extraction(
 
         # Index the extracted memories
         if extracted_memories:
-            await index_long_term_memories(extracted_memories)
+            await index_long_term_memories(
+                extracted_memories,
+                deduplicate=True,
+            )
             logger.info(
                 f"Trailing extraction completed for session {session_id}: "
                 f"{len(extracted_memories)} memories extracted and indexed"

--- a/tests/test_extraction_logic_fix.py
+++ b/tests/test_extraction_logic_fix.py
@@ -198,6 +198,7 @@ class TestExtractionLogicFixes:
                 indexed_memories = mock_index.call_args[0][0]
                 assert len(indexed_memories) == 1
                 assert indexed_memories[0].id == "extracted-1"
+                assert mock_index.call_args.kwargs.get("deduplicate") is True
 
                 # Verify working memory was updated - messages marked as extracted
                 updated_wm = await get_working_memory(


### PR DESCRIPTION
## Summary
- pass `deduplicate=True` when delayed extraction indexes memories
- preserve existing delayed extraction behavior while preventing duplicate long-term entries
- assert the deduplication flag in `test_extraction_logic_fix`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enables deduplication in the delayed/trailing extraction indexing path, which can change what long-term memory records are persisted (skip/merge/delete duplicates). Impact is limited to trailing extraction but touches data integrity behavior.
> 
> **Overview**
> **Trailing-edge (delayed) extraction now indexes with deduplication enabled.** `run_delayed_extraction` passes `deduplicate=True` into `index_long_term_memories`, preventing duplicate long-term entries when delayed extraction runs.
> 
> Tests are updated to assert the `deduplicate` flag is set on the indexing call during delayed extraction.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c0dcc47a8caaf5c0b44fae4c8e98a6436ae94c4a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->