### PR TITLE
fix: Standardize namespace before userId parameter order in Java SDK

### DIFF
--- a/agent-memory-client/agent-memory-client-java/src/main/java/com/redis/agentmemory/services/WorkingMemoryService.java
+++ b/agent-memory-client/agent-memory-client-java/src/main/java/com/redis/agentmemory/services/WorkingMemoryService.java
@@ -89,8 +89,8 @@ public class WorkingMemoryService extends BaseService {
      * Get working memory for a session.
      *
      * @param sessionId The session ID to retrieve working memory for
-     * @param userId The user ID to retrieve working memory for
      * @param namespace Optional namespace for the session
+     * @param userId The user ID to retrieve working memory for
      * @param modelName Optional model name to determine context window size
      * @param contextWindowMax Optional direct specification of context window tokens
      * @return WorkingMemoryResponse containing messages, context and metadata
@@ -98,8 +98,8 @@ public class WorkingMemoryService extends BaseService {
      */
     public WorkingMemoryResponse getWorkingMemory(
             @NotNull String sessionId,
-            @Nullable String userId,
             @Nullable String namespace,
+            @Nullable String userId,
             @Nullable String modelName,
             @Nullable Integer contextWindowMax
     ) throws MemoryClientException {
@@ -160,8 +160,8 @@ public class WorkingMemoryService extends BaseService {
      *
      * @param sessionId The session ID
      * @param memory The working memory to store
-     * @param userId Optional user ID
      * @param namespace Optional namespace
+     * @param userId Optional user ID
      * @param modelName Optional model name
      * @param contextWindowMax Optional context window max
      * @return WorkingMemoryResponse with the stored memory
@@ -170,8 +170,8 @@ public class WorkingMemoryService extends BaseService {
     public WorkingMemoryResponse putWorkingMemory(
             @NotNull String sessionId,
             @NotNull WorkingMemory memory,
-            @Nullable String userId,
             @Nullable String namespace,
+            @Nullable String userId,
             @Nullable String modelName,
             @Nullable Integer contextWindowMax
     ) throws MemoryClientException {
@@ -238,15 +238,15 @@ public class WorkingMemoryService extends BaseService {
      * Delete working memory for a session.
      *
      * @param sessionId The session ID to delete
-     * @param userId Optional user ID
      * @param namespace Optional namespace
+     * @param userId Optional user ID
      * @return AckResponse indicating success
      * @throws MemoryClientException if the request fails
      */
     public AckResponse deleteWorkingMemory(
             @NotNull String sessionId,
-            @Nullable String userId,
-            @Nullable String namespace
+            @Nullable String namespace,
+            @Nullable String userId
     ) throws MemoryClientException {
         HttpUrl.Builder urlBuilder = HttpUrl.parse(
                 baseUrl + "/v1/working-memory/" + sessionId
@@ -309,7 +309,7 @@ public class WorkingMemoryService extends BaseService {
             @Nullable MemoryStrategyConfig longTermMemoryStrategy) throws MemoryClientException {
         try {
             // Try to get existing memory
-            WorkingMemoryResponse existing = getWorkingMemory(sessionId, userId, namespace, modelName, contextWindowMax);
+            WorkingMemoryResponse existing = getWorkingMemory(sessionId, namespace, userId, modelName, contextWindowMax);
             return new WorkingMemoryResult(false, existing);
         } catch (MemoryNotFoundException e) {
             // Memory doesn't exist, create it
@@ -323,7 +323,7 @@ public class WorkingMemoryService extends BaseService {
                     .longTermMemoryStrategy(longTermMemoryStrategy != null ? longTermMemoryStrategy : MemoryStrategyConfig.builder().build())
                     .build();
 
-            WorkingMemoryResponse created = putWorkingMemory(sessionId, emptyMemory, userId, namespace, modelName, contextWindowMax);
+            WorkingMemoryResponse created = putWorkingMemory(sessionId, emptyMemory, namespace, userId, modelName, contextWindowMax);
             return new WorkingMemoryResult(true, created);
         }
     }
@@ -368,7 +368,7 @@ public class WorkingMemoryService extends BaseService {
                 .longTermMemoryStrategy(existing.getLongTermMemoryStrategy())
                 .build();
 
-        return putWorkingMemory(sessionId, updated, userId, namespace, null, null);
+        return putWorkingMemory(sessionId, updated, namespace, userId, null, null);
     }
 
     /**
@@ -508,7 +508,7 @@ public class WorkingMemoryService extends BaseService {
                 .longTermMemoryStrategy(existing.getLongTermMemoryStrategy())
                 .build();
 
-        return putWorkingMemory(sessionId, updated, userId, namespace, null, null);
+        return putWorkingMemory(sessionId, updated, namespace, userId, null, null);
     }
 
     /**
@@ -553,7 +553,7 @@ public class WorkingMemoryService extends BaseService {
                 .longTermMemoryStrategy(existing.getLongTermMemoryStrategy())
                 .build();
 
-        return putWorkingMemory(sessionId, updated, userId, namespace, modelName, contextWindowMax);
+        return putWorkingMemory(sessionId, updated, namespace, userId, modelName, contextWindowMax);
     }
 
     /**

--- a/agent-memory-client/agent-memory-client-java/src/test/java/com/redis/agentmemory/integration/WorkingMemoryIntegrationTest.java
+++ b/agent-memory-client/agent-memory-client-java/src/test/java/com/redis/agentmemory/integration/WorkingMemoryIntegrationTest.java
@@ -55,6 +55,7 @@ class WorkingMemoryIntegrationTest extends BaseIntegrationTest {
         Thread.sleep(100);
 
         // Retrieve working memory
+        // Note: getWorkingMemory signature is (sessionId, namespace, userId, modelName, contextWindowMax)
         WorkingMemoryResponse getResponse = client.workingMemory()
                 .getWorkingMemory(sessionId, namespace, null, null, null);
 
@@ -297,5 +298,70 @@ class WorkingMemoryIntegrationTest extends BaseIntegrationTest {
         assertEquals(2, response.getData().get("counter"));
         assertEquals("new_value", response.getData().get("new_field"));
         assertEquals("active", response.getData().get("status"));  // Should still exist
+    }
+
+    @Test
+    void testCreateMultipleWorkingMemoriesAndRetrieveEach() throws Exception {
+        String namespace = "integration-test-multiple";
+        String sessionId1 = "multi-session-1-" + UUID.randomUUID();
+        String sessionId2 = "multi-session-2-" + UUID.randomUUID();
+        String sessionId3 = "multi-session-3-" + UUID.randomUUID();
+
+        // Create three working memories with different content
+        // Note: userId is part of the Redis key, so we need to use the same userId when retrieving
+        WorkingMemory memory1 = WorkingMemory.builder()
+                .sessionId(sessionId1)
+                .namespace(namespace)
+                .messages(Collections.singletonList(
+                        MemoryMessage.builder().role("user").content("First session message").build()))
+                .build();
+
+        WorkingMemory memory2 = WorkingMemory.builder()
+                .sessionId(sessionId2)
+                .namespace(namespace)
+                .messages(Collections.singletonList(
+                        MemoryMessage.builder().role("user").content("Second session message").build()))
+                .build();
+
+        WorkingMemory memory3 = WorkingMemory.builder()
+                .sessionId(sessionId3)
+                .namespace(namespace)
+                .messages(Collections.singletonList(
+                        MemoryMessage.builder().role("user").content("Third session message").build()))
+                .build();
+
+        // Store all three working memories
+        client.workingMemory().putWorkingMemory(sessionId1, memory1, null, null, null, null);
+        client.workingMemory().putWorkingMemory(sessionId2, memory2, null, null, null, null);
+        client.workingMemory().putWorkingMemory(sessionId3, memory3, null, null, null, null);
+
+        // Small delay to ensure data is persisted
+        Thread.sleep(200);
+
+        // Retrieve each working memory individually and verify
+        // Note: getWorkingMemory signature is (sessionId, namespace, userId, modelName, contextWindowMax)
+        WorkingMemoryResponse retrieved1 = client.workingMemory()
+                .getWorkingMemory(sessionId1, namespace, null, null, null);
+        assertNotNull(retrieved1);
+        assertEquals(sessionId1, retrieved1.getSessionId());
+        assertNotNull(retrieved1.getMessages());
+        assertFalse(retrieved1.getMessages().isEmpty());
+        assertEquals("First session message", retrieved1.getMessages().get(0).getContent());
+
+        WorkingMemoryResponse retrieved2 = client.workingMemory()
+                .getWorkingMemory(sessionId2, namespace, null, null, null);
+        assertNotNull(retrieved2);
+        assertEquals(sessionId2, retrieved2.getSessionId());
+        assertNotNull(retrieved2.getMessages());
+        assertFalse(retrieved2.getMessages().isEmpty());
+        assertEquals("Second session message", retrieved2.getMessages().get(0).getContent());
+
+        WorkingMemoryResponse retrieved3 = client.workingMemory()
+                .getWorkingMemory(sessionId3, namespace, null, null, null);
+        assertNotNull(retrieved3);
+        assertEquals(sessionId3, retrieved3.getSessionId());
+        assertNotNull(retrieved3.getMessages());
+        assertFalse(retrieved3.getMessages().isEmpty());
+        assertEquals("Third session message", retrieved3.getMessages().get(0).getContent());
     }
 }

--- a/agent-memory-client/agent-memory-client-java/src/test/java/com/redis/agentmemory/services/WorkingMemoryServiceTest.java
+++ b/agent-memory-client/agent-memory-client-java/src/test/java/com/redis/agentmemory/services/WorkingMemoryServiceTest.java
@@ -169,7 +169,7 @@ class WorkingMemoryServiceTest {
                 .addHeader("Content-Type", "application/json"));
 
         // Execute
-        AckResponse response = client.workingMemory().deleteWorkingMemory("session-123", "user-456", "test-namespace");
+        AckResponse response = client.workingMemory().deleteWorkingMemory("session-123", "test-namespace", "user-456");
 
         // Verify
         assertNotNull(response);


### PR DESCRIPTION
## Summary
Fixes inconsistent parameter ordering in `WorkingMemoryService` that caused confusion and bugs

## Changes
- Standardized all methods to use `namespace` before `userId` parameter order
- Updated internal method calls within the service
- Fixed affected tests

## Breaking Change
This changes the method signatures for:
- `getWorkingMemory`
- `putWorkingMemory`  
- `deleteWorkingMemory`

Callers passing explicit values for both `namespace` and `userId` will need to swap the argument order.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is a **breaking SDK API change**: it reorders public method parameters for `getWorkingMemory`, `putWorkingMemory`, and `deleteWorkingMemory`, so existing callers passing both `namespace` and `userId` may silently swap values and hit wrong keys/queries if not updated.
> 
> **Overview**
> Standardizes `WorkingMemoryService` public APIs to use consistent parameter ordering with `namespace` before `userId` for `getWorkingMemory`, `putWorkingMemory`, and `deleteWorkingMemory`, and updates all internal call sites to match.
> 
> Updates unit/integration tests to use the new signature, and adds an integration test that creates multiple working memories and verifies each can be retrieved independently.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 63df6cce08c09d9ada5f5784690b03bce3a293e9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->