### PR TITLE
fix: Preserve tokens and TTL in working memory update methods

### DIFF
--- a/agent-memory-client/agent-memory-client-java/src/main/java/com/redis/agentmemory/services/WorkingMemoryService.java
+++ b/agent-memory-client/agent-memory-client-java/src/main/java/com/redis/agentmemory/services/WorkingMemoryService.java
@@ -365,10 +365,12 @@ public class WorkingMemoryService extends BaseService {
                 .data(data)
                 .context(existing.getContext())
                 .userId(existing.getUserId())
+                .tokens(existing.getTokens())
+                .ttlSeconds(existing.getTtlSeconds())
                 .longTermMemoryStrategy(existing.getLongTermMemoryStrategy())
                 .build();
 
-        return putWorkingMemory(sessionId, updated, userId, namespace, null, null);
+        return putWorkingMemory(sessionId, updated, namespace, userId, null, null);
     }
 
     /**
@@ -434,10 +436,12 @@ public class WorkingMemoryService extends BaseService {
                 .data(existing.getData())
                 .context(existing.getContext())
                 .userId(existing.getUserId())
+                .tokens(existing.getTokens())
+                .ttlSeconds(existing.getTtlSeconds())
                 .longTermMemoryStrategy(existing.getLongTermMemoryStrategy())
                 .build();
 
-        return putWorkingMemory(sessionId, updated, null, namespace, null, null);
+        return putWorkingMemory(sessionId, updated, namespace, null, null, null);
     }
 
     /**
@@ -505,15 +509,100 @@ public class WorkingMemoryService extends BaseService {
                 .data(finalData)
                 .context(existing.getContext())
                 .userId(existing.getUserId())
+                .tokens(existing.getTokens())
+                .ttlSeconds(existing.getTtlSeconds())
                 .longTermMemoryStrategy(existing.getLongTermMemoryStrategy())
                 .build();
 
-        return putWorkingMemory(sessionId, updated, userId, namespace, null, null);
+        return putWorkingMemory(sessionId, updated, namespace, userId, null, null);
     }
 
     /**
      * Append new messages to existing working memory.
      * More efficient than retrieving, modifying, and setting full memory.
+     *
+     * @param sessionId The session ID
+     * @param messages List of messages to append
+     * @param namespace Optional namespace
+     * @param modelName Optional model name for token-based summarization
+     * @param contextWindowMax Optional context window max tokens
+     * @param userId Optional user ID
+     * @param tokens Optional token count for the updated messages (if null, preserves existing token count)
+     * @param ttlSeconds Optional TTL in seconds to restart the session expiration (if null, preserves existing TTL)
+     * @return WorkingMemoryResponse with updated memory (potentially summarized if token limit exceeded)
+     * @throws MemoryClientException if the request fails
+     */
+    public WorkingMemoryResponse appendMessagesToWorkingMemory(
+            @NotNull String sessionId,
+            @NotNull List<MemoryMessage> messages,
+            @Nullable String namespace,
+            @Nullable String modelName,
+            @Nullable Integer contextWindowMax,
+            @Nullable String userId,
+            @Nullable Integer tokens,
+            @Nullable Integer ttlSeconds) throws MemoryClientException {
+        // Get existing memory
+        WorkingMemoryResult result = getOrCreateWorkingMemory(sessionId, namespace, userId, null, null, null);
+        WorkingMemoryResponse existing = result.getMemory();
+
+        // Get existing messages
+        List<MemoryMessage> existingMessages = new ArrayList<>(existing.getMessages());
+
+        // Append new messages
+        existingMessages.addAll(messages);
+
+        // Determine token count: use provided value, or preserve existing
+        int tokenCount = tokens != null ? tokens : existing.getTokens();
+
+        // Determine TTL: use provided value, or preserve existing
+        Integer ttl = ttlSeconds != null ? ttlSeconds : existing.getTtlSeconds();
+
+        // Create updated working memory
+        WorkingMemory updated = WorkingMemory.builder()
+                .sessionId(sessionId)
+                .namespace(namespace != null ? namespace : defaultNamespace)
+                .messages(existingMessages)
+                .memories(existing.getMemories())
+                .data(existing.getData())
+                .context(existing.getContext())
+                .userId(userId != null ? userId : existing.getUserId())
+                .tokens(tokenCount)
+                .ttlSeconds(ttl)
+                .longTermMemoryStrategy(existing.getLongTermMemoryStrategy())
+                .build();
+
+        return putWorkingMemory(sessionId, updated, namespace, userId, modelName, contextWindowMax);
+    }
+
+    /**
+     * Append new messages to existing working memory without specifying tokens or TTL.
+     * Preserves the existing token count and TTL from the session.
+     *
+     * @param sessionId The session ID
+     * @param messages List of messages to append
+     * @param namespace Optional namespace
+     * @param modelName Optional model name for token-based summarization
+     * @param contextWindowMax Optional context window max tokens
+     * @param userId Optional user ID
+     * @param tokens Optional token count for the updated messages (if null, preserves existing token count)
+     * @return WorkingMemoryResponse with updated memory (potentially summarized if token limit exceeded)
+     * @throws MemoryClientException if the request fails
+     */
+    public WorkingMemoryResponse appendMessagesToWorkingMemory(
+            @NotNull String sessionId,
+            @NotNull List<MemoryMessage> messages,
+            @Nullable String namespace,
+            @Nullable String modelName,
+            @Nullable Integer contextWindowMax,
+            @Nullable String userId,
+            @Nullable Integer tokens) throws MemoryClientException {
+        return appendMessagesToWorkingMemory(sessionId, messages, namespace, modelName,
+                contextWindowMax, userId, tokens, null);
+    }
+
+    /**
+     * Append new messages to existing working memory without specifying tokens or TTL.
+     * Preserves the existing token count and TTL from the session.
      *
      * @param sessionId The session ID
      * @param messages List of messages to append
@@ -531,29 +620,8 @@ public class WorkingMemoryService extends BaseService {
             @Nullable String modelName,
             @Nullable Integer contextWindowMax,
             @Nullable String userId) throws MemoryClientException {
-        // Get existing memory
-        WorkingMemoryResult result = getOrCreateWorkingMemory(sessionId, namespace, userId, null, null, null);
-        WorkingMemoryResponse existing = result.getMemory();
-
-        // Get existing messages
-        List<MemoryMessage> existingMessages = new ArrayList<>(existing.getMessages());
-
-        // Append new messages
-        existingMessages.addAll(messages);
-
-        // Create updated working memory
-        WorkingMemory updated = WorkingMemory.builder()
-                .sessionId(sessionId)
-                .namespace(namespace != null ? namespace : defaultNamespace)
-                .messages(existingMessages)
-                .memories(existing.getMemories())
-                .data(existing.getData())
-                .context(existing.getContext())
-                .userId(userId != null ? userId : existing.getUserId())
-                .longTermMemoryStrategy(existing.getLongTermMemoryStrategy())
-                .build();
-
-        return putWorkingMemory(sessionId, updated, userId, namespace, modelName, contextWindowMax);
+        return appendMessagesToWorkingMemory(sessionId, messages, namespace, modelName,
+                contextWindowMax, userId, null, null);
     }
 
     /**
@@ -568,7 +636,7 @@ public class WorkingMemoryService extends BaseService {
             @NotNull String sessionId,
             @NotNull List<MemoryMessage> messages) throws MemoryClientException {
         return appendMessagesToWorkingMemory(sessionId, messages, defaultNamespace,
-                null, null, null);
+                null, null, null, null, null);
     }
 
     // ===== Helper Methods =====

--- a/agent-memory-client/agent-memory-client-java/src/test/java/com/redis/agentmemory/integration/WorkingMemoryIntegrationTest.java
+++ b/agent-memory-client/agent-memory-client-java/src/test/java/com/redis/agentmemory/integration/WorkingMemoryIntegrationTest.java
@@ -298,4 +298,182 @@ class WorkingMemoryIntegrationTest extends BaseIntegrationTest {
         assertEquals("new_value", response.getData().get("new_field"));
         assertEquals("active", response.getData().get("status"));  // Should still exist
     }
+
+    @Test
+    void testAppendMessagesWithTokens() throws Exception {
+        String sessionId = "append-tokens-test-" + UUID.randomUUID();
+        String namespace = "integration-test";
+
+        // Create initial working memory with some tokens
+        WorkingMemory initialMemory = WorkingMemory.builder()
+                .sessionId(sessionId)
+                .namespace(namespace)
+                .messages(Collections.singletonList(
+                        MemoryMessage.builder().role("user").content("Hello").build()))
+                .tokens(100)
+                .build();
+
+        client.workingMemory().putWorkingMemory(sessionId, initialMemory, namespace, null, null, null);
+
+        // Verify initial tokens
+        WorkingMemoryResponse initial = client.workingMemory()
+                .getWorkingMemory(sessionId, namespace, null, null, null);
+        assertEquals(100, initial.getTokens());
+
+        // Append messages with updated token count
+        List<MemoryMessage> newMessages = Collections.singletonList(
+                MemoryMessage.builder().role("assistant").content("Hi there! How can I help?").build());
+
+        WorkingMemoryResponse response = client.workingMemory()
+                .appendMessagesToWorkingMemory(sessionId, newMessages, namespace, null, null, null, 250);
+
+        assertNotNull(response);
+        assertEquals(250, response.getTokens());
+        assertTrue(response.getMessages().size() >= 2);
+
+        // Verify tokens persisted
+        WorkingMemoryResponse retrieved = client.workingMemory()
+                .getWorkingMemory(sessionId, namespace, null, null, null);
+        assertEquals(250, retrieved.getTokens());
+    }
+
+    @Test
+    void testAppendMessagesPreservesExistingTokens() throws Exception {
+        String sessionId = "preserve-tokens-test-" + UUID.randomUUID();
+        String namespace = "integration-test";
+
+        // Create initial working memory with tokens
+        WorkingMemory initialMemory = WorkingMemory.builder()
+                .sessionId(sessionId)
+                .namespace(namespace)
+                .messages(Collections.singletonList(
+                        MemoryMessage.builder().role("user").content("Hello").build()))
+                .tokens(150)
+                .build();
+
+        client.workingMemory().putWorkingMemory(sessionId, initialMemory, namespace, null, null, null);
+
+        // Append messages WITHOUT specifying tokens (should preserve existing 150)
+        List<MemoryMessage> newMessages = Collections.singletonList(
+                MemoryMessage.builder().role("assistant").content("Hi!").build());
+
+        WorkingMemoryResponse response = client.workingMemory()
+                .appendMessagesToWorkingMemory(sessionId, newMessages, namespace, null, null, null);
+
+        assertNotNull(response);
+        assertEquals(150, response.getTokens()); // Should preserve existing
+        assertTrue(response.getMessages().size() >= 2);
+
+        // Verify tokens persisted
+        WorkingMemoryResponse retrieved = client.workingMemory()
+                .getWorkingMemory(sessionId, namespace, null, null, null);
+        assertEquals(150, retrieved.getTokens());
+    }
+
+    @Test
+    void testAppendMessagesWithTtl() throws Exception {
+        String sessionId = "append-ttl-test-" + UUID.randomUUID();
+        String namespace = "integration-test";
+
+        // Create initial working memory with TTL
+        WorkingMemory initialMemory = WorkingMemory.builder()
+                .sessionId(sessionId)
+                .namespace(namespace)
+                .messages(Collections.singletonList(
+                        MemoryMessage.builder().role("user").content("Hello").build()))
+                .ttlSeconds(1800) // 30 minutes
+                .build();
+
+        client.workingMemory().putWorkingMemory(sessionId, initialMemory, namespace, null, null, null);
+
+        // Verify initial TTL
+        WorkingMemoryResponse initial = client.workingMemory()
+                .getWorkingMemory(sessionId, namespace, null, null, null);
+        assertEquals(Integer.valueOf(1800), initial.getTtlSeconds());
+
+        // Append messages with new TTL (restart to 1 hour)
+        List<MemoryMessage> newMessages = Collections.singletonList(
+                MemoryMessage.builder().role("assistant").content("Hi there!").build());
+
+        WorkingMemoryResponse response = client.workingMemory()
+                .appendMessagesToWorkingMemory(sessionId, newMessages, namespace, null, null, null, null, 3600);
+
+        assertNotNull(response);
+        assertEquals(Integer.valueOf(3600), response.getTtlSeconds());
+        assertTrue(response.getMessages().size() >= 2);
+
+        // Verify TTL persisted
+        WorkingMemoryResponse retrieved = client.workingMemory()
+                .getWorkingMemory(sessionId, namespace, null, null, null);
+        assertEquals(Integer.valueOf(3600), retrieved.getTtlSeconds());
+    }
+
+    @Test
+    void testAppendMessagesPreservesExistingTtl() throws Exception {
+        String sessionId = "preserve-ttl-test-" + UUID.randomUUID();
+        String namespace = "integration-test";
+
+        // Create initial working memory with TTL
+        WorkingMemory initialMemory = WorkingMemory.builder()
+                .sessionId(sessionId)
+                .namespace(namespace)
+                .messages(Collections.singletonList(
+                        MemoryMessage.builder().role("user").content("Hello").build()))
+                .ttlSeconds(1800) // 30 minutes
+                .build();
+
+        client.workingMemory().putWorkingMemory(sessionId, initialMemory, namespace, null, null, null);
+
+        // Append messages WITHOUT specifying TTL (should preserve existing)
+        List<MemoryMessage> newMessages = Collections.singletonList(
+                MemoryMessage.builder().role("assistant").content("Hi!").build());
+
+        WorkingMemoryResponse response = client.workingMemory()
+                .appendMessagesToWorkingMemory(sessionId, newMessages, namespace, null, null, null);
+
+        assertNotNull(response);
+        assertEquals(Integer.valueOf(1800), response.getTtlSeconds()); // Should preserve existing
+        assertTrue(response.getMessages().size() >= 2);
+
+        // Verify TTL persisted
+        WorkingMemoryResponse retrieved = client.workingMemory()
+                .getWorkingMemory(sessionId, namespace, null, null, null);
+        assertEquals(Integer.valueOf(1800), retrieved.getTtlSeconds());
+    }
+
+    @Test
+    void testAppendMessagesWithTokensAndTtl() throws Exception {
+        String sessionId = "append-tokens-ttl-test-" + UUID.randomUUID();
+        String namespace = "integration-test";
+
+        // Create initial working memory with tokens and TTL
+        WorkingMemory initialMemory = WorkingMemory.builder()
+                .sessionId(sessionId)
+                .namespace(namespace)
+                .messages(Collections.singletonList(
+                        MemoryMessage.builder().role("user").content("Hello").build()))
+                .tokens(100)
+                .ttlSeconds(1800)
+                .build();
+
+        client.workingMemory().putWorkingMemory(sessionId, initialMemory, namespace, null, null, null);
+
+        // Append messages with both new tokens and new TTL
+        List<MemoryMessage> newMessages = Collections.singletonList(
+                MemoryMessage.builder().role("assistant").content("Hi there!").build());
+
+        WorkingMemoryResponse response = client.workingMemory()
+                .appendMessagesToWorkingMemory(sessionId, newMessages, namespace, null, null, null, 250, 3600);
+
+        assertNotNull(response);
+        assertEquals(250, response.getTokens());
+        assertEquals(Integer.valueOf(3600), response.getTtlSeconds());
+        assertTrue(response.getMessages().size() >= 2);
+
+        // Verify both persisted
+        WorkingMemoryResponse retrieved = client.workingMemory()
+                .getWorkingMemory(sessionId, namespace, null, null, null);
+        assertEquals(250, retrieved.getTokens());
+        assertEquals(Integer.valueOf(3600), retrieved.getTtlSeconds());
+    }
 }

--- a/agent-memory-client/agent-memory-client-java/src/test/java/com/redis/agentmemory/services/WorkingMemoryServiceTest.java
+++ b/agent-memory-client/agent-memory-client-java/src/test/java/com/redis/agentmemory/services/WorkingMemoryServiceTest.java
@@ -277,4 +277,245 @@ class WorkingMemoryServiceTest {
         assertNotNull(request.getPath());
         assertTrue(request.getPath().contains("/v1/working-memory/session-123"));
     }
+
+    @Test
+    void testAppendMessagesToWorkingMemory_WithTokens() throws Exception {
+        // Mock GET response for existing memory with existing tokens
+        WorkingMemoryResponse existingResponse = new WorkingMemoryResponse();
+        existingResponse.setSessionId("session-123");
+        existingResponse.setNamespace("test-namespace");
+        existingResponse.setMessages(Arrays.asList(new MemoryMessage("user", "Hello")));
+        existingResponse.setMemories(new ArrayList<>());
+        existingResponse.setData(new HashMap<>());
+        existingResponse.setTokens(100);
+
+        mockServer.enqueue(new MockResponse()
+                .setBody(objectMapper.writeValueAsString(existingResponse))
+                .addHeader("Content-Type", "application/json"));
+
+        // Mock PUT response after appending
+        WorkingMemoryResponse updatedResponse = new WorkingMemoryResponse();
+        updatedResponse.setSessionId("session-123");
+        updatedResponse.setNamespace("test-namespace");
+        updatedResponse.setMessages(Arrays.asList(
+                new MemoryMessage("user", "Hello"),
+                new MemoryMessage("assistant", "Hi there!")
+        ));
+        updatedResponse.setTokens(250);
+
+        mockServer.enqueue(new MockResponse()
+                .setBody(objectMapper.writeValueAsString(updatedResponse))
+                .addHeader("Content-Type", "application/json"));
+
+        // Execute - append messages with explicit token count
+        List<MemoryMessage> newMessages = Arrays.asList(new MemoryMessage("assistant", "Hi there!"));
+        WorkingMemoryResponse response = client.workingMemory().appendMessagesToWorkingMemory(
+                "session-123", newMessages, "test-namespace", null, null, null, 250);
+
+        // Verify
+        assertNotNull(response);
+        assertEquals("session-123", response.getSessionId());
+        assertEquals(250, response.getTokens());
+
+        // Verify the PUT request contains the tokens
+        mockServer.takeRequest(); // GET request
+        RecordedRequest putRequest = mockServer.takeRequest();
+        assertEquals("PUT", putRequest.getMethod());
+        String body = putRequest.getBody().readUtf8();
+        assertTrue(body.contains("\"tokens\":250"));
+    }
+
+    @Test
+    void testAppendMessagesToWorkingMemory_PreservesExistingTokens() throws Exception {
+        // Mock GET response for existing memory with tokens
+        WorkingMemoryResponse existingResponse = new WorkingMemoryResponse();
+        existingResponse.setSessionId("session-123");
+        existingResponse.setNamespace("test-namespace");
+        existingResponse.setMessages(Arrays.asList(new MemoryMessage("user", "Hello")));
+        existingResponse.setMemories(new ArrayList<>());
+        existingResponse.setData(new HashMap<>());
+        existingResponse.setTokens(150);
+
+        mockServer.enqueue(new MockResponse()
+                .setBody(objectMapper.writeValueAsString(existingResponse))
+                .addHeader("Content-Type", "application/json"));
+
+        // Mock PUT response
+        WorkingMemoryResponse updatedResponse = new WorkingMemoryResponse();
+        updatedResponse.setSessionId("session-123");
+        updatedResponse.setTokens(150); // Should preserve existing
+
+        mockServer.enqueue(new MockResponse()
+                .setBody(objectMapper.writeValueAsString(updatedResponse))
+                .addHeader("Content-Type", "application/json"));
+
+        // Execute - append messages WITHOUT specifying tokens (should preserve existing)
+        List<MemoryMessage> newMessages = Arrays.asList(new MemoryMessage("assistant", "Hi!"));
+        WorkingMemoryResponse response = client.workingMemory().appendMessagesToWorkingMemory(
+                "session-123", newMessages, "test-namespace", null, null, null);
+
+        // Verify the PUT request preserves existing tokens
+        mockServer.takeRequest(); // GET request
+        RecordedRequest putRequest = mockServer.takeRequest();
+        String body = putRequest.getBody().readUtf8();
+        assertTrue(body.contains("\"tokens\":150"));
+    }
+
+    @Test
+    void testAppendMessagesToWorkingMemory_MinimalParams() throws Exception {
+        // Mock GET response
+        WorkingMemoryResponse existingResponse = new WorkingMemoryResponse();
+        existingResponse.setSessionId("session-123");
+        existingResponse.setMessages(new ArrayList<>());
+        existingResponse.setMemories(new ArrayList<>());
+        existingResponse.setData(new HashMap<>());
+        existingResponse.setTokens(0);
+
+        mockServer.enqueue(new MockResponse()
+                .setBody(objectMapper.writeValueAsString(existingResponse))
+                .addHeader("Content-Type", "application/json"));
+
+        // Mock PUT response
+        WorkingMemoryResponse updatedResponse = new WorkingMemoryResponse();
+        updatedResponse.setSessionId("session-123");
+
+        mockServer.enqueue(new MockResponse()
+                .setBody(objectMapper.writeValueAsString(updatedResponse))
+                .addHeader("Content-Type", "application/json"));
+
+        // Execute with minimal params
+        List<MemoryMessage> newMessages = Arrays.asList(new MemoryMessage("user", "Test"));
+        WorkingMemoryResponse response = client.workingMemory().appendMessagesToWorkingMemory(
+                "session-123", newMessages);
+
+        // Verify
+        assertNotNull(response);
+        assertEquals("session-123", response.getSessionId());
+
+        RecordedRequest getRequest = mockServer.takeRequest();
+        assertEquals("GET", getRequest.getMethod());
+
+        RecordedRequest putRequest = mockServer.takeRequest();
+        assertEquals("PUT", putRequest.getMethod());
+    }
+
+    @Test
+    void testAppendMessagesToWorkingMemory_WithTtl() throws Exception {
+        // Mock GET response for existing memory with TTL
+        WorkingMemoryResponse existingResponse = new WorkingMemoryResponse();
+        existingResponse.setSessionId("session-123");
+        existingResponse.setNamespace("test-namespace");
+        existingResponse.setMessages(Arrays.asList(new MemoryMessage("user", "Hello")));
+        existingResponse.setMemories(new ArrayList<>());
+        existingResponse.setData(new HashMap<>());
+        existingResponse.setTtlSeconds(1800); // 30 minutes
+
+        mockServer.enqueue(new MockResponse()
+                .setBody(objectMapper.writeValueAsString(existingResponse))
+                .addHeader("Content-Type", "application/json"));
+
+        // Mock PUT response
+        WorkingMemoryResponse updatedResponse = new WorkingMemoryResponse();
+        updatedResponse.setSessionId("session-123");
+        updatedResponse.setTtlSeconds(3600); // 1 hour
+
+        mockServer.enqueue(new MockResponse()
+                .setBody(objectMapper.writeValueAsString(updatedResponse))
+                .addHeader("Content-Type", "application/json"));
+
+        // Execute - append messages with new TTL (restart to 1 hour)
+        List<MemoryMessage> newMessages = Arrays.asList(new MemoryMessage("assistant", "Hi!"));
+        WorkingMemoryResponse response = client.workingMemory().appendMessagesToWorkingMemory(
+                "session-123", newMessages, "test-namespace", null, null, null, null, 3600);
+
+        // Verify
+        assertNotNull(response);
+        assertEquals(Integer.valueOf(3600), response.getTtlSeconds());
+
+        // Verify the PUT request contains the new TTL
+        mockServer.takeRequest(); // GET request
+        RecordedRequest putRequest = mockServer.takeRequest();
+        String body = putRequest.getBody().readUtf8();
+        assertTrue(body.contains("\"ttl_seconds\":3600"));
+    }
+
+    @Test
+    void testAppendMessagesToWorkingMemory_PreservesExistingTtl() throws Exception {
+        // Mock GET response for existing memory with TTL
+        WorkingMemoryResponse existingResponse = new WorkingMemoryResponse();
+        existingResponse.setSessionId("session-123");
+        existingResponse.setNamespace("test-namespace");
+        existingResponse.setMessages(Arrays.asList(new MemoryMessage("user", "Hello")));
+        existingResponse.setMemories(new ArrayList<>());
+        existingResponse.setData(new HashMap<>());
+        existingResponse.setTtlSeconds(1800); // 30 minutes
+
+        mockServer.enqueue(new MockResponse()
+                .setBody(objectMapper.writeValueAsString(existingResponse))
+                .addHeader("Content-Type", "application/json"));
+
+        // Mock PUT response
+        WorkingMemoryResponse updatedResponse = new WorkingMemoryResponse();
+        updatedResponse.setSessionId("session-123");
+        updatedResponse.setTtlSeconds(1800);
+
+        mockServer.enqueue(new MockResponse()
+                .setBody(objectMapper.writeValueAsString(updatedResponse))
+                .addHeader("Content-Type", "application/json"));
+
+        // Execute - append messages WITHOUT specifying TTL (should preserve existing)
+        List<MemoryMessage> newMessages = Arrays.asList(new MemoryMessage("assistant", "Hi!"));
+        WorkingMemoryResponse response = client.workingMemory().appendMessagesToWorkingMemory(
+                "session-123", newMessages, "test-namespace", null, null, null);
+
+        // Verify the PUT request preserves existing TTL
+        mockServer.takeRequest(); // GET request
+        RecordedRequest putRequest = mockServer.takeRequest();
+        String body = putRequest.getBody().readUtf8();
+        assertTrue(body.contains("\"ttl_seconds\":1800"));
+    }
+
+    @Test
+    void testAppendMessagesToWorkingMemory_WithTokensAndTtl() throws Exception {
+        // Mock GET response
+        WorkingMemoryResponse existingResponse = new WorkingMemoryResponse();
+        existingResponse.setSessionId("session-123");
+        existingResponse.setNamespace("test-namespace");
+        existingResponse.setMessages(Arrays.asList(new MemoryMessage("user", "Hello")));
+        existingResponse.setMemories(new ArrayList<>());
+        existingResponse.setData(new HashMap<>());
+        existingResponse.setTokens(100);
+        existingResponse.setTtlSeconds(1800);
+
+        mockServer.enqueue(new MockResponse()
+                .setBody(objectMapper.writeValueAsString(existingResponse))
+                .addHeader("Content-Type", "application/json"));
+
+        // Mock PUT response
+        WorkingMemoryResponse updatedResponse = new WorkingMemoryResponse();
+        updatedResponse.setSessionId("session-123");
+        updatedResponse.setTokens(250);
+        updatedResponse.setTtlSeconds(3600);
+
+        mockServer.enqueue(new MockResponse()
+                .setBody(objectMapper.writeValueAsString(updatedResponse))
+                .addHeader("Content-Type", "application/json"));
+
+        // Execute - append messages with both tokens and TTL
+        List<MemoryMessage> newMessages = Arrays.asList(new MemoryMessage("assistant", "Hi!"));
+        WorkingMemoryResponse response = client.workingMemory().appendMessagesToWorkingMemory(
+                "session-123", newMessages, "test-namespace", null, null, null, 250, 3600);
+
+        // Verify
+        assertNotNull(response);
+        assertEquals(250, response.getTokens());
+        assertEquals(Integer.valueOf(3600), response.getTtlSeconds());
+
+        // Verify the PUT request contains both values
+        mockServer.takeRequest(); // GET request
+        RecordedRequest putRequest = mockServer.takeRequest();
+        String body = putRequest.getBody().readUtf8();
+        assertTrue(body.contains("\"tokens\":250"));
+        assertTrue(body.contains("\"ttl_seconds\":3600"));
+    }
 }


### PR DESCRIPTION
## Summary
Working memory update methods were losing `tokens` and `ttlSeconds` values. 
This PR preserves these fields and adds parameters to set them when appending messages.

## Changes
- `appendMessagesToWorkingMemory`: Added optional `tokens` and `ttlSeconds` parameters
- `setWorkingMemoryData`, `addMemoriesToWorkingMemory`, `updateWorkingMemoryData`: Now preserve existing `tokens` and `ttlSeconds`
- Added unit and integration tests

## Usage
```java
// Restart TTL to 1 hour and update token count when appending messages
client.workingMemory().appendMessagesToWorkingMemory(
    sessionId, messages, namespace, modelName, 
    contextWindowMax, userId, 250, 3600);
```

## Breaking Change
None - new parameters are optional and existing method signatures are preserved.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how enhanced working-memory methods call `putWorkingMemory` (swapping `namespace`/`userId` argument positions) and adjusts `appendMessagesToWorkingMemory` signatures/overloads, which could alter request query parameters or client behavior if relied upon.
> 
> **Overview**
> Fixes working-memory update flows to **retain `tokens` and `ttlSeconds`** when rebuilding `WorkingMemory` in `setWorkingMemoryData`, `addMemoriesToWorkingMemory`, and `updateWorkingMemoryData`.
> 
> Extends `appendMessagesToWorkingMemory` to accept optional `tokens` and `ttlSeconds` (defaulting to existing values when omitted) and adds overloads to keep existing call sites working.
> 
> Adds unit + integration tests to verify token/TTL preservation and persistence when appending messages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 345fdd122c5e90a5bef3c3851ed069f7230c4e07. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->