### PR TITLE
feat: Add recency boost support to SearchRequest

### DIFF
--- a/agent-memory-client/agent-memory-client-java/src/main/java/com/redis/agentmemory/models/longtermemory/SearchRequest.java
+++ b/agent-memory-client/agent-memory-client-java/src/main/java/com/redis/agentmemory/models/longtermemory/SearchRequest.java
@@ -40,6 +40,39 @@ public class SearchRequest {
 
     private int offset = 0;
 
+    // Recency boost parameters
+    @Nullable
+    @JsonProperty("recency_boost")
+    private Boolean recencyBoost;
+
+    @Nullable
+    @JsonProperty("recency_semantic_weight")
+    private Double recencySemanticWeight;
+
+    @Nullable
+    @JsonProperty("recency_recency_weight")
+    private Double recencyRecencyWeight;
+
+    @Nullable
+    @JsonProperty("recency_freshness_weight")
+    private Double recencyFreshnessWeight;
+
+    @Nullable
+    @JsonProperty("recency_novelty_weight")
+    private Double recencyNoveltyWeight;
+
+    @Nullable
+    @JsonProperty("recency_half_life_last_access_days")
+    private Double recencyHalfLifeLastAccessDays;
+
+    @Nullable
+    @JsonProperty("recency_half_life_created_days")
+    private Double recencyHalfLifeCreatedDays;
+
+    @Nullable
+    @JsonProperty("server_side_recency")
+    private Boolean serverSideRecency;
+
     public SearchRequest() {
     }
 
@@ -122,6 +155,78 @@ public class SearchRequest {
         this.offset = offset;
     }
 
+    @Nullable
+    public Boolean getRecencyBoost() {
+        return recencyBoost;
+    }
+
+    public void setRecencyBoost(@Nullable Boolean recencyBoost) {
+        this.recencyBoost = recencyBoost;
+    }
+
+    @Nullable
+    public Double getRecencySemanticWeight() {
+        return recencySemanticWeight;
+    }
+
+    public void setRecencySemanticWeight(@Nullable Double recencySemanticWeight) {
+        this.recencySemanticWeight = recencySemanticWeight;
+    }
+
+    @Nullable
+    public Double getRecencyRecencyWeight() {
+        return recencyRecencyWeight;
+    }
+
+    public void setRecencyRecencyWeight(@Nullable Double recencyRecencyWeight) {
+        this.recencyRecencyWeight = recencyRecencyWeight;
+    }
+
+    @Nullable
+    public Double getRecencyFreshnessWeight() {
+        return recencyFreshnessWeight;
+    }
+
+    public void setRecencyFreshnessWeight(@Nullable Double recencyFreshnessWeight) {
+        this.recencyFreshnessWeight = recencyFreshnessWeight;
+    }
+
+    @Nullable
+    public Double getRecencyNoveltyWeight() {
+        return recencyNoveltyWeight;
+    }
+
+    public void setRecencyNoveltyWeight(@Nullable Double recencyNoveltyWeight) {
+        this.recencyNoveltyWeight = recencyNoveltyWeight;
+    }
+
+    @Nullable
+    public Double getRecencyHalfLifeLastAccessDays() {
+        return recencyHalfLifeLastAccessDays;
+    }
+
+    public void setRecencyHalfLifeLastAccessDays(@Nullable Double recencyHalfLifeLastAccessDays) {
+        this.recencyHalfLifeLastAccessDays = recencyHalfLifeLastAccessDays;
+    }
+
+    @Nullable
+    public Double getRecencyHalfLifeCreatedDays() {
+        return recencyHalfLifeCreatedDays;
+    }
+
+    public void setRecencyHalfLifeCreatedDays(@Nullable Double recencyHalfLifeCreatedDays) {
+        this.recencyHalfLifeCreatedDays = recencyHalfLifeCreatedDays;
+    }
+
+    @Nullable
+    public Boolean getServerSideRecency() {
+        return serverSideRecency;
+    }
+
+    public void setServerSideRecency(@Nullable Boolean serverSideRecency) {
+        this.serverSideRecency = serverSideRecency;
+    }
+
     @Override
     public String toString() {
         return "SearchRequest{" +
@@ -134,6 +239,14 @@ public class SearchRequest {
                 ", distanceThreshold=" + distanceThreshold +
                 ", limit=" + limit +
                 ", offset=" + offset +
+                ", recencyBoost=" + recencyBoost +
+                ", recencySemanticWeight=" + recencySemanticWeight +
+                ", recencyRecencyWeight=" + recencyRecencyWeight +
+                ", recencyFreshnessWeight=" + recencyFreshnessWeight +
+                ", recencyNoveltyWeight=" + recencyNoveltyWeight +
+                ", recencyHalfLifeLastAccessDays=" + recencyHalfLifeLastAccessDays +
+                ", recencyHalfLifeCreatedDays=" + recencyHalfLifeCreatedDays +
+                ", serverSideRecency=" + serverSideRecency +
                 '}';
     }
 
@@ -193,6 +306,46 @@ public class SearchRequest {
 
         public Builder offset(int offset) {
             request.offset = offset;
+            return this;
+        }
+
+        public Builder recencyBoost(@Nullable Boolean recencyBoost) {
+            request.recencyBoost = recencyBoost;
+            return this;
+        }
+
+        public Builder recencySemanticWeight(@Nullable Double recencySemanticWeight) {
+            request.recencySemanticWeight = recencySemanticWeight;
+            return this;
+        }
+
+        public Builder recencyRecencyWeight(@Nullable Double recencyRecencyWeight) {
+            request.recencyRecencyWeight = recencyRecencyWeight;
+            return this;
+        }
+
+        public Builder recencyFreshnessWeight(@Nullable Double recencyFreshnessWeight) {
+            request.recencyFreshnessWeight = recencyFreshnessWeight;
+            return this;
+        }
+
+        public Builder recencyNoveltyWeight(@Nullable Double recencyNoveltyWeight) {
+            request.recencyNoveltyWeight = recencyNoveltyWeight;
+            return this;
+        }
+
+        public Builder recencyHalfLifeLastAccessDays(@Nullable Double recencyHalfLifeLastAccessDays) {
+            request.recencyHalfLifeLastAccessDays = recencyHalfLifeLastAccessDays;
+            return this;
+        }
+
+        public Builder recencyHalfLifeCreatedDays(@Nullable Double recencyHalfLifeCreatedDays) {
+            request.recencyHalfLifeCreatedDays = recencyHalfLifeCreatedDays;
+            return this;
+        }
+
+        public Builder serverSideRecency(@Nullable Boolean serverSideRecency) {
+            request.serverSideRecency = serverSideRecency;
             return this;
         }
 

--- a/agent-memory-client/agent-memory-client-java/src/main/java/com/redis/agentmemory/services/LongTermMemoryService.java
+++ b/agent-memory-client/agent-memory-client-java/src/main/java/com/redis/agentmemory/services/LongTermMemoryService.java
@@ -96,6 +96,35 @@ public class LongTermMemoryService extends BaseService {
         if (request.getEntities() != null && !request.getEntities().isEmpty()) {
             payload.put("entities", Map.of("any", request.getEntities()));
         }
+        if (request.getDistanceThreshold() != null) {
+            payload.put("distance_threshold", request.getDistanceThreshold());
+        }
+
+        // Add recency boost parameters if present
+        if (request.getRecencyBoost() != null) {
+            payload.put("recency_boost", request.getRecencyBoost());
+        }
+        if (request.getRecencySemanticWeight() != null) {
+            payload.put("recency_semantic_weight", request.getRecencySemanticWeight());
+        }
+        if (request.getRecencyRecencyWeight() != null) {
+            payload.put("recency_recency_weight", request.getRecencyRecencyWeight());
+        }
+        if (request.getRecencyFreshnessWeight() != null) {
+            payload.put("recency_freshness_weight", request.getRecencyFreshnessWeight());
+        }
+        if (request.getRecencyNoveltyWeight() != null) {
+            payload.put("recency_novelty_weight", request.getRecencyNoveltyWeight());
+        }
+        if (request.getRecencyHalfLifeLastAccessDays() != null) {
+            payload.put("recency_half_life_last_access_days", request.getRecencyHalfLifeLastAccessDays());
+        }
+        if (request.getRecencyHalfLifeCreatedDays() != null) {
+            payload.put("recency_half_life_created_days", request.getRecencyHalfLifeCreatedDays());
+        }
+        if (request.getServerSideRecency() != null) {
+            payload.put("server_side_recency", request.getServerSideRecency());
+        }
 
         try {
             String json = objectMapper.writeValueAsString(payload);

--- a/agent-memory-client/agent-memory-client-java/src/test/java/com/redis/agentmemory/integration/LongTermMemoryIntegrationTest.java
+++ b/agent-memory-client/agent-memory-client-java/src/test/java/com/redis/agentmemory/integration/LongTermMemoryIntegrationTest.java
@@ -436,4 +436,127 @@ class LongTermMemoryIntegrationTest extends BaseIntegrationTest {
         // Should have retrieved some memories
         assertTrue(count >= 0);
     }
+
+    @Test
+    void testSearchWithRecencyBoost() throws Exception {
+        String namespace = "integration-test-recency";
+        String userId = "recency-user-" + UUID.randomUUID();
+
+        // Create memories
+        List<MemoryRecord> memories = Arrays.asList(
+                MemoryRecord.builder()
+                        .text("User prefers morning meetings")
+                        .namespace(namespace)
+                        .userId(userId)
+                        .memoryType(MemoryType.SEMANTIC)
+                        .topics(Collections.singletonList("preferences"))
+                        .build(),
+                MemoryRecord.builder()
+                        .text("User likes afternoon coffee breaks")
+                        .namespace(namespace)
+                        .userId(userId)
+                        .memoryType(MemoryType.SEMANTIC)
+                        .topics(Collections.singletonList("preferences"))
+                        .build()
+        );
+
+        client.longTermMemory().createLongTermMemories(memories);
+        Thread.sleep(2000);
+
+        // Search with recency boost enabled
+        SearchRequest searchRequest = SearchRequest.builder()
+                .text("user preferences")
+                .namespace(namespace)
+                .userId(userId)
+                .recencyBoost(true)
+                .recencySemanticWeight(0.7)
+                .recencyRecencyWeight(0.3)
+                .recencyHalfLifeLastAccessDays(7.0)
+                .recencyHalfLifeCreatedDays(30.0)
+                .serverSideRecency(true)
+                .limit(10)
+                .build();
+
+        MemoryRecordResults results = client.longTermMemory()
+                .searchLongTermMemories(searchRequest);
+
+        assertNotNull(results);
+        assertNotNull(results.getMemories());
+        // Results depend on embeddings being available
+        assertTrue(results.getMemories().size() >= 0);
+    }
+
+    @Test
+    void testSearchWithRecencyBoostDisabled() throws Exception {
+        String namespace = "integration-test-no-recency";
+        String userId = "no-recency-user-" + UUID.randomUUID();
+
+        // Create a memory
+        MemoryRecord memory = MemoryRecord.builder()
+                .text("Test memory without recency boost")
+                .namespace(namespace)
+                .userId(userId)
+                .memoryType(MemoryType.SEMANTIC)
+                .build();
+
+        client.longTermMemory().createLongTermMemories(Collections.singletonList(memory));
+        Thread.sleep(2000);
+
+        // Search with recency boost explicitly disabled (pure semantic search)
+        SearchRequest searchRequest = SearchRequest.builder()
+                .text("test memory")
+                .namespace(namespace)
+                .userId(userId)
+                .recencyBoost(false)
+                .limit(10)
+                .build();
+
+        MemoryRecordResults results = client.longTermMemory()
+                .searchLongTermMemories(searchRequest);
+
+        assertNotNull(results);
+        assertNotNull(results.getMemories());
+    }
+
+    @Test
+    void testSearchWithDistanceThreshold() throws Exception {
+        String namespace = "integration-test-distance";
+        String userId = "distance-user-" + UUID.randomUUID();
+
+        // Create memories
+        List<MemoryRecord> memories = Arrays.asList(
+                MemoryRecord.builder()
+                        .text("Python is a great programming language")
+                        .namespace(namespace)
+                        .userId(userId)
+                        .memoryType(MemoryType.SEMANTIC)
+                        .build(),
+                MemoryRecord.builder()
+                        .text("Java is used for enterprise applications")
+                        .namespace(namespace)
+                        .userId(userId)
+                        .memoryType(MemoryType.SEMANTIC)
+                        .build()
+        );
+
+        client.longTermMemory().createLongTermMemories(memories);
+        Thread.sleep(2000);
+
+        // Search with strict distance threshold (only very similar results)
+        SearchRequest searchRequest = SearchRequest.builder()
+                .text("Python programming")
+                .namespace(namespace)
+                .userId(userId)
+                .distanceThreshold(0.3)  // Strict threshold
+                .limit(10)
+                .build();
+
+        MemoryRecordResults results = client.longTermMemory()
+                .searchLongTermMemories(searchRequest);
+
+        assertNotNull(results);
+        assertNotNull(results.getMemories());
+        // With strict threshold, we may get fewer or no results
+        assertTrue(results.getMemories().size() >= 0);
+    }
 }

--- a/agent-memory-client/agent-memory-client-java/src/test/java/com/redis/agentmemory/services/LongTermMemoryServiceTest.java
+++ b/agent-memory-client/agent-memory-client-java/src/test/java/com/redis/agentmemory/services/LongTermMemoryServiceTest.java
@@ -290,4 +290,129 @@ class LongTermMemoryServiceTest {
         assertTrue(request.getPath().contains("dry_run=true"));
     }
 
+    @Test
+    void testSearchLongTermMemories_WithRecencyBoost() throws Exception {
+        // Mock response
+        MemoryRecordResults expectedResponse = new MemoryRecordResults();
+        expectedResponse.setMemories(new ArrayList<>());
+        expectedResponse.setTotal(0);
+
+        mockServer.enqueue(new MockResponse()
+                .setBody(objectMapper.writeValueAsString(expectedResponse))
+                .addHeader("Content-Type", "application/json"));
+
+        // Execute - with recency boost parameters
+        SearchRequest searchRequest = SearchRequest.builder()
+                .text("test query")
+                .userId("user-123")
+                .recencyBoost(true)
+                .recencySemanticWeight(0.7)
+                .recencyRecencyWeight(0.3)
+                .recencyFreshnessWeight(0.6)
+                .recencyNoveltyWeight(0.4)
+                .recencyHalfLifeLastAccessDays(7.0)
+                .recencyHalfLifeCreatedDays(30.0)
+                .serverSideRecency(true)
+                .build();
+        MemoryRecordResults response = client.longTermMemory().searchLongTermMemories(searchRequest);
+
+        // Verify response
+        assertNotNull(response);
+        assertEquals(0, response.getTotal());
+
+        // Verify request payload contains recency parameters
+        RecordedRequest request = mockServer.takeRequest();
+        assertEquals("POST", request.getMethod());
+        String requestBody = request.getBody().readUtf8();
+
+        assertTrue(requestBody.contains("\"recency_boost\":true"));
+        assertTrue(requestBody.contains("\"recency_semantic_weight\":0.7"));
+        assertTrue(requestBody.contains("\"recency_recency_weight\":0.3"));
+        assertTrue(requestBody.contains("\"recency_freshness_weight\":0.6"));
+        assertTrue(requestBody.contains("\"recency_novelty_weight\":0.4"));
+        assertTrue(requestBody.contains("\"recency_half_life_last_access_days\":7.0"));
+        assertTrue(requestBody.contains("\"recency_half_life_created_days\":30.0"));
+        assertTrue(requestBody.contains("\"server_side_recency\":true"));
+    }
+
+    @Test
+    void testSearchLongTermMemories_WithRecencyBoostDisabled() throws Exception {
+        // Mock response
+        MemoryRecordResults expectedResponse = new MemoryRecordResults();
+        expectedResponse.setMemories(new ArrayList<>());
+        expectedResponse.setTotal(0);
+
+        mockServer.enqueue(new MockResponse()
+                .setBody(objectMapper.writeValueAsString(expectedResponse))
+                .addHeader("Content-Type", "application/json"));
+
+        // Execute - with recency boost disabled
+        SearchRequest searchRequest = SearchRequest.builder()
+                .text("test query")
+                .recencyBoost(false)
+                .build();
+        MemoryRecordResults response = client.longTermMemory().searchLongTermMemories(searchRequest);
+
+        // Verify response
+        assertNotNull(response);
+
+        // Verify request payload contains recency_boost: false
+        RecordedRequest request = mockServer.takeRequest();
+        String requestBody = request.getBody().readUtf8();
+        assertTrue(requestBody.contains("\"recency_boost\":false"));
+    }
+
+    @Test
+    void testSearchLongTermMemories_WithDistanceThreshold() throws Exception {
+        // Mock response
+        MemoryRecordResults expectedResponse = new MemoryRecordResults();
+        expectedResponse.setMemories(new ArrayList<>());
+        expectedResponse.setTotal(0);
+
+        mockServer.enqueue(new MockResponse()
+                .setBody(objectMapper.writeValueAsString(expectedResponse))
+                .addHeader("Content-Type", "application/json"));
+
+        // Execute - with distance threshold
+        SearchRequest searchRequest = SearchRequest.builder()
+                .text("test query")
+                .distanceThreshold(0.35)
+                .build();
+        MemoryRecordResults response = client.longTermMemory().searchLongTermMemories(searchRequest);
+
+        // Verify response
+        assertNotNull(response);
+
+        // Verify request payload contains distance_threshold
+        RecordedRequest request = mockServer.takeRequest();
+        String requestBody = request.getBody().readUtf8();
+        assertTrue(requestBody.contains("\"distance_threshold\":0.35"));
+    }
+
+    @Test
+    void testSearchRequestBuilder_AllRecencyFields() {
+        // Test that all recency fields can be set via builder
+        SearchRequest request = SearchRequest.builder()
+                .text("query")
+                .recencyBoost(true)
+                .recencySemanticWeight(0.8)
+                .recencyRecencyWeight(0.2)
+                .recencyFreshnessWeight(0.5)
+                .recencyNoveltyWeight(0.5)
+                .recencyHalfLifeLastAccessDays(14.0)
+                .recencyHalfLifeCreatedDays(60.0)
+                .serverSideRecency(false)
+                .build();
+
+        assertEquals("query", request.getText());
+        assertTrue(request.getRecencyBoost());
+        assertEquals(0.8, request.getRecencySemanticWeight());
+        assertEquals(0.2, request.getRecencyRecencyWeight());
+        assertEquals(0.5, request.getRecencyFreshnessWeight());
+        assertEquals(0.5, request.getRecencyNoveltyWeight());
+        assertEquals(14.0, request.getRecencyHalfLifeLastAccessDays());
+        assertEquals(60.0, request.getRecencyHalfLifeCreatedDays());
+        assertFalse(request.getServerSideRecency());
+    }
+
 }


### PR DESCRIPTION
## Summary
Adds recency boost support to the Java SDK's `SearchRequest`, enabling control over memory decay in search results.

## Changes
- `SearchRequest`: Added 8 recency boost fields with builder support
- `LongTermMemoryService`: Include recency params in search payload
- Added 4 unit tests for recency boost functionality

## Usage
```java
SearchRequest request = SearchRequest.builder()
    .text("query")
    .recencyBoost(true)
    .recencySemanticWeight(0.7)
    .recencyRecencyWeight(0.3)
    .serverSideRecency(true)
    .build();
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are additive optional fields and request-payload wiring for search, plus tests. Main impact is that search requests may now include new/previously-ignored parameters (`recency_*`, `server_side_recency`, `distance_threshold`) when set, which can change search results.
> 
> **Overview**
> Adds **recency-boost tuning controls** to `SearchRequest` (new `recency_*` weights/half-lives plus `server_side_recency`) with getters/setters, builder methods, and `toString` updates.
> 
> Updates `LongTermMemoryService.searchLongTermMemories` to include `distance_threshold` and any provided recency parameters in the JSON payload, and adds unit + integration tests asserting these fields are serialized and accepted in search calls.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8726e62f125ebdaee851b6fefa7f39b35766bc10. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->