### PR TITLE
fix: guard extract_memory_structure HSET and gate semantic dedup on setting

### DIFF
--- a/agent_memory_server/long_term_memory.py
+++ b/agent_memory_server/long_term_memory.py
@@ -514,22 +514,17 @@ async def extract_memory_structure(
     # Guard: only update if the key still exists. A race between semantic
     # deduplication (which deletes merged keys) and this background task
     # can recreate deleted keys as orphaned hashes with only topics/entities.
-    # Use a Lua script to perform the existence check and HSET atomically,
-    # closing the TOCTOU window where the key could be deleted between the
-    # EXISTS and HSET calls.
+    # Use HSETEX with FXX to atomically update only if the fields already
+    # exist on the hash — a deleted key has no fields, so nothing is written.
     key = Keys.memory_key(memory.id)
-    lua_script = """
-    if redis.call('EXISTS', KEYS[1]) == 1 then
-        redis.call('HSET', KEYS[1], ARGV[1], ARGV[2], ARGV[3], ARGV[4])
-        return 1
-    else
-        return 0
-    end
-    """
-    result = await redis.eval(
-        lua_script, 1, key,
-        "topics", encode_tag_values(merged_topics),
-        "entities", encode_tag_values(merged_entities),
+    result = await redis.hsetex(
+        key,
+        mapping={
+            "topics": encode_tag_values(merged_topics),
+            "entities": encode_tag_values(merged_entities),
+        },
+        data_persist_option="FXX",
+        keepttl=True,
     )
     if result == 0:
         logger.info(f"Skipping topic/entity update for deleted memory {memory.id}")

--- a/tests/test_long_term_memory.py
+++ b/tests/test_long_term_memory.py
@@ -325,30 +325,26 @@ class TestLongTermMemory:
                 memory_type=MemoryTypeEnum.SEMANTIC,
             )
 
-            # Simulate key exists (Lua script returns 1)
-            mock_redis.eval.return_value = 1
+            # Simulate key exists (HSETEX FXX returns number of fields set)
+            mock_redis.hsetex.return_value = 2
 
             await extract_memory_structure(memory)
 
             # Verify extraction was called
             mock_extract.assert_called_once_with("Test text content")
 
-            # Verify Redis eval was called with atomic Lua script
-            mock_redis.eval.assert_called_once()
-            args = mock_redis.eval.call_args[0]
-
-            # args: (lua_script, 1, key, "topics", topics, "entities", entities)
-            lua_script = args[0]
-            assert "EXISTS" in lua_script
-            assert "HSET" in lua_script
-            key = args[2]
+            # Verify HSETEX was called with FXX for atomic guard
+            mock_redis.hsetex.assert_called_once()
+            call_kwargs = mock_redis.hsetex.call_args
+            key = call_kwargs[0][0]
             assert "memory_idx:" in key and "test-id" in key
 
-            # Check comma-separated values passed to Lua script
-            assert args[3] == "topics"
-            assert args[4] == "topic1,topic2"
-            assert args[5] == "entities"
-            assert args[6] == "entity1,entity2"
+            # Check comma-separated values and FXX flag
+            mapping = call_kwargs[1]["mapping"]
+            assert mapping["topics"] == "topic1,topic2"
+            assert mapping["entities"] == "entity1,entity2"
+            assert call_kwargs[1]["data_persist_option"] == "FXX"
+            assert call_kwargs[1]["keepttl"] is True
 
     @pytest.mark.asyncio
     async def test_update_long_term_memory_preserves_decoded_tags_on_text_only_patch(
@@ -400,8 +396,9 @@ class TestLongTermMemory:
         """Regression: extract_memory_structure must not recreate deleted keys.
 
         When semantic deduplication deletes a memory key between scheduling
-        and execution of the background extraction task, the atomic Lua script
-        must detect the missing key and skip the HSET to avoid orphaned hashes.
+        and execution of the background extraction task, HSETEX with FXX
+        must detect the missing fields and skip the update to avoid orphaned
+        hashes.
         """
         with (
             patch(
@@ -415,8 +412,8 @@ class TestLongTermMemory:
             mock_get_redis.return_value = mock_redis
             mock_extract.return_value = (["topic1"], ["entity1"])
 
-            # Simulate key does NOT exist (Lua script returns 0)
-            mock_redis.eval.return_value = 0
+            # Simulate key does NOT exist (HSETEX FXX returns 0)
+            mock_redis.hsetex.return_value = 0
 
             memory = MemoryRecord(
                 id="deleted-id",
@@ -428,8 +425,8 @@ class TestLongTermMemory:
             # Should complete without error, skipping the update
             await extract_memory_structure(memory)
 
-            # Lua script was called (it handles the existence check internally)
-            mock_redis.eval.assert_called_once()
+            # HSETEX was called (FXX handles the existence check)
+            mock_redis.hsetex.assert_called_once()
             # hset should NOT have been called directly
             mock_redis.hset.assert_not_called()
 


### PR DESCRIPTION
## Problem

Two related bugs that cause orphaned Redis keys and unexpected semantic deduplication behavior.

### Bug 1: Orphaned keys from extract_memory_structure race condition

`extract_memory_structure` (background task) does a raw `HSET` on the memory key to update topics/entities. If the memory was deleted between when the task was scheduled and when it executes (e.g., by semantic deduplication merging it into another memory), the `HSET` **recreates** the key as an orphaned hash with only `topics` and `entities` fields — no `text`, `id_`, `memory_type`, or vector embedding.

These orphaned keys:
- Are returned by `FT.SEARCH` queries (they match the index prefix)
- Have no usable content (empty text, empty id)
- Cannot be deleted via the `delete_long_term_memories` API (no id to reference)
- Accumulate over time as dedup/compaction runs

**Reproduction:** Create memories that trigger semantic deduplication. The deleted duplicates' pending `extract_memory_structure` tasks will recreate their keys as orphans.

**Evidence from production:** Found 19 orphaned keys in Redis — all had only `topics` and `entities` fields, confirmed via `HKEYS`.

### Bug 2: Semantic dedup during indexing ignores compact_semantic_duplicates setting

`index_long_term_memories` calls `deduplicate_by_semantic_search` unconditionally when `deduplicate=True`. The `compact_semantic_duplicates` setting (wired to `COMPACT_SEMANTIC_DUPLICATES` env var) only gates periodic compaction in `compact_long_term_memories`, not this indexing-time path.

Setting `COMPACT_SEMANTIC_DUPLICATES=false` gives a false sense of safety — semantic dedup still runs on every memory write.

## Fix

1. **Atomic Lua guard** in `extract_memory_structure` — a Lua script performs `EXISTS` + `HSET` atomically so there is no TOCTOU window where a concurrent delete could slip between the check and the write.

2. **Gate semantic dedup in `index_long_term_memories`** on `settings.compact_semantic_duplicates` — respect the setting consistently across both code paths.

## Testing

- `test_extract_memory_structure` — verifies the Lua script is called with correct key and pipe-separated values
- `test_extract_memory_structure_skips_deleted_key` — verifies no update when Lua returns 0 (key gone)
- `test_compact_semantic_duplicates_env_var` — verifies env var parsing
- `test_index_skips_semantic_dedup_when_disabled` — verifies `deduplicate_by_semantic_search` is not called when setting is False

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches long-term memory indexing and Redis persistence semantics; mistakes could cause missed topic/entity enrichment or unexpected dedup/merges during writes.
> 
> **Overview**
> Prevents `extract_memory_structure` (background topic/entity extraction) from recreating deleted long-term memory Redis hashes by switching the update to `HSETEX` with `FXX` + `keepttl`, and logging/skip behavior when the key no longer exists.
> 
> Updates `index_long_term_memories` so indexing-time semantic deduplication only runs when `settings.compact_semantic_duplicates` is enabled, aligning runtime behavior with the env-configured setting.
> 
> Adjusts and adds tests to cover the guarded Redis update path (existing vs deleted key) and to assert semantic dedup is skipped when the setting is disabled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d9e616546278013bdca261dc1addaa35f8cc674a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->