### PR TITLE
Allow patching pinned on long-term memories

### DIFF
--- a/agent_memory_server/long_term_memory.py
+++ b/agent_memory_server/long_term_memory.py
@@ -1882,6 +1882,7 @@ async def update_long_term_memory(
         "user_id",
         "session_id",
         "event_date",
+        "pinned",
     }
 
     # Validate update fields

--- a/agent_memory_server/mcp.py
+++ b/agent_memory_server/mcp.py
@@ -1017,6 +1017,7 @@ async def edit_long_term_memory(
     user_id: str | None = None,
     session_id: str | None = None,
     event_date: str | None = None,
+    pinned: bool | None = None,
 ) -> MemoryRecord:
     """
     Edit an existing long-term memory by its ID.
@@ -1037,6 +1038,7 @@ async def edit_long_term_memory(
         user_id: Updated user ID associated with the memory
         session_id: Updated session ID where the memory originated
         event_date: Updated event date for episodic memories (ISO 8601 format: "2024-01-15T14:30:00Z")
+        pinned: Whether this memory is pinned and protected from auto-deletion
 
     Returns:
         The updated memory record
@@ -1124,6 +1126,7 @@ async def edit_long_term_memory(
         "event_date": (
             _parse_iso8601_datetime(event_date) if event_date is not None else None
         ),
+        "pinned": pinned,
     }
 
     # Filter out None values to only include fields that should be updated

--- a/agent_memory_server/models.py
+++ b/agent_memory_server/models.py
@@ -879,6 +879,10 @@ class EditMemoryRecordRequest(BaseModel):
     event_date: datetime | None = Field(
         default=None, description="Updated event date for episodic memories"
     )
+    pinned: bool | None = Field(
+        default=None,
+        description="Whether this memory is pinned and should not be auto-deleted",
+    )
 
 
 class TaskStatusEnum(str, Enum):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,4 +1,5 @@
-from unittest.mock import MagicMock, patch
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -1421,6 +1422,94 @@ class TestLongTermMemoryEndpoint:
 
         # Verify delete function was called with empty list
         mock_delete.assert_called_once_with(ids=[])
+
+    @pytest.mark.asyncio
+    async def test_patch_long_term_memory_allows_pinned_only(self, client):
+        """Test patching a long-term memory with only pinned."""
+        mock_settings = Settings(long_term_memory=True)
+        now = datetime.now(UTC).isoformat()
+        updated_memory = {
+            "id": "memory-1",
+            "text": "Pinned memory",
+            "session_id": "session-1",
+            "user_id": "user-1",
+            "namespace": "ns-1",
+            "memory_type": "semantic",
+            "topics": [],
+            "entities": [],
+            "memory_hash": "hash-1",
+            "discrete_memory_extracted": "f",
+            "pinned": True,
+            "access_count": 0,
+            "created_at": now,
+            "updated_at": now,
+            "last_accessed": now,
+            "persisted_at": now,
+            "extraction_strategy": "discrete",
+            "extraction_strategy_config": {},
+        }
+
+        with (
+            patch("agent_memory_server.api.settings", mock_settings),
+            patch(
+                "agent_memory_server.api.long_term_memory.update_long_term_memory",
+                new=AsyncMock(return_value=updated_memory),
+            ) as mock_update,
+        ):
+            response = await client.patch(
+                "/v1/long-term-memory/memory-1",
+                json={"pinned": True},
+            )
+
+        assert response.status_code == 200
+        assert response.json()["pinned"] is True
+        mock_update.assert_awaited_once_with("memory-1", {"pinned": True})
+
+    @pytest.mark.asyncio
+    async def test_patch_long_term_memory_allows_pinned_with_text(self, client):
+        """Test patching pinned alongside another editable field."""
+        mock_settings = Settings(long_term_memory=True)
+        now = datetime.now(UTC).isoformat()
+        updated_memory = {
+            "id": "memory-1",
+            "text": "Updated memory",
+            "session_id": "session-1",
+            "user_id": "user-1",
+            "namespace": "ns-1",
+            "memory_type": "semantic",
+            "topics": [],
+            "entities": [],
+            "memory_hash": "hash-2",
+            "discrete_memory_extracted": "f",
+            "pinned": False,
+            "access_count": 0,
+            "created_at": now,
+            "updated_at": now,
+            "last_accessed": now,
+            "persisted_at": now,
+            "extraction_strategy": "discrete",
+            "extraction_strategy_config": {},
+        }
+
+        with (
+            patch("agent_memory_server.api.settings", mock_settings),
+            patch(
+                "agent_memory_server.api.long_term_memory.update_long_term_memory",
+                new=AsyncMock(return_value=updated_memory),
+            ) as mock_update,
+        ):
+            response = await client.patch(
+                "/v1/long-term-memory/memory-1",
+                json={"text": "Updated memory", "pinned": False},
+            )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["text"] == "Updated memory"
+        assert body["pinned"] is False
+        mock_update.assert_awaited_once_with(
+            "memory-1", {"text": "Updated memory", "pinned": False}
+        )
 
 
 class TestDeprecationHeader:

--- a/tests/test_long_term_memory.py
+++ b/tests/test_long_term_memory.py
@@ -17,6 +17,7 @@ from agent_memory_server.long_term_memory import (
     merge_memories_with_llm,
     promote_working_memory_to_long_term,
     search_long_term_memories,
+    update_long_term_memory,
 )
 from agent_memory_server.models import (
     MemoryRecord,
@@ -122,6 +123,70 @@ class TestLongTermMemory:
         assert results.memories[0].text == "Hello, world!"
         assert results.memories[0].dist == 0.25
         assert results.memories[0].memory_type == "message"
+
+    @pytest.mark.asyncio
+    async def test_update_long_term_memory_allows_pinned_true(self):
+        """Test pinning an existing long-term memory."""
+        existing_memory = MemoryRecord(
+            id="memory-1",
+            text="Original memory",
+            session_id="session-1",
+            user_id="user-1",
+            namespace="ns-1",
+            memory_type=MemoryTypeEnum.SEMANTIC,
+            pinned=False,
+        )
+        mock_adapter = AsyncMock()
+
+        with (
+            patch(
+                "agent_memory_server.long_term_memory.get_long_term_memory_by_id",
+                new=AsyncMock(return_value=existing_memory),
+            ),
+            patch(
+                "agent_memory_server.long_term_memory.get_memory_vector_db",
+                new=AsyncMock(return_value=mock_adapter),
+            ),
+        ):
+            updated = await update_long_term_memory("memory-1", {"pinned": True})
+
+        assert updated is not None
+        assert updated.pinned is True
+        mock_adapter.update_memories.assert_awaited_once()
+        stored_memory = mock_adapter.update_memories.await_args.args[0][0]
+        assert stored_memory.pinned is True
+
+    @pytest.mark.asyncio
+    async def test_update_long_term_memory_allows_pinned_false(self):
+        """Test unpinning an existing long-term memory."""
+        existing_memory = MemoryRecord(
+            id="memory-1",
+            text="Original memory",
+            session_id="session-1",
+            user_id="user-1",
+            namespace="ns-1",
+            memory_type=MemoryTypeEnum.SEMANTIC,
+            pinned=True,
+        )
+        mock_adapter = AsyncMock()
+
+        with (
+            patch(
+                "agent_memory_server.long_term_memory.get_long_term_memory_by_id",
+                new=AsyncMock(return_value=existing_memory),
+            ),
+            patch(
+                "agent_memory_server.long_term_memory.get_memory_vector_db",
+                new=AsyncMock(return_value=mock_adapter),
+            ),
+        ):
+            updated = await update_long_term_memory("memory-1", {"pinned": False})
+
+        assert updated is not None
+        assert updated.pinned is False
+        mock_adapter.update_memories.assert_awaited_once()
+        stored_memory = mock_adapter.update_memories.await_args.args[0][0]
+        assert stored_memory.pinned is False
 
     @pytest.mark.asyncio
     async def test_deduplicate_by_id(self, mock_async_redis_client):

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -681,3 +681,30 @@ class TestMCP:
                     user_id="user-123",
                     session_id=None,
                 )
+
+    @pytest.mark.asyncio
+    async def test_edit_long_term_memory_allows_pinned(self, mcp_test_setup):
+        """Test the MCP edit_long_term_memory tool passes pinned updates through."""
+        async with client_session(mcp_app._mcp_server) as client:
+            with mock.patch(
+                "agent_memory_server.mcp.core_update_long_term_memory"
+            ) as mock_update:
+                mock_update.return_value = MemoryRecord(
+                    id="memory-1",
+                    text="Pinned memory",
+                    session_id="session-1",
+                    user_id="user-1",
+                    namespace="ns-1",
+                    pinned=True,
+                )
+
+                result = await client.call_tool(
+                    "edit_long_term_memory",
+                    {"memory_id": "memory-1", "pinned": True},
+                )
+
+                assert isinstance(result, CallToolResult)
+                mock_update.assert_awaited_once()
+                call_args = mock_update.await_args
+                assert call_args.kwargs["memory_id"] == "memory-1"
+                assert call_args.kwargs["updates"].pinned is True


### PR DESCRIPTION
Enables editing pinned on existing long-term memories via `PATCH /v1/long-term-memory/{memory_id}`

This adds pinned to the edit request model, allows it in the server update path, keeps MCP edit parity, and adds focused regression tests for API, service, and MCP behavior.

Fixes https://github.com/redis/agent-memory-server/issues/175

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, additive change that only extends the long-term memory edit path to accept an optional `pinned` flag; behavior is covered by new API/service/MCP regression tests.
> 
> **Overview**
> **Adds support for editing `pinned` on existing long-term memories.** The `PATCH /v1/long-term-memory/{memory_id}` update path now allows `pinned` in the server-side updatable field set and in the `EditMemoryRecordRequest` model.
> 
> Keeps MCP parity by extending `edit_long_term_memory` to accept/pass through `pinned`, and adds focused tests covering API patch requests and the underlying `update_long_term_memory` behavior for pin/unpin.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 851fca1336c3bfcb041a6e523b782fdcdcb94097. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->