### PR TITLE
fix: add task status transition guards

### DIFF
--- a/agent_memory_server/tasks.py
+++ b/agent_memory_server/tasks.py
@@ -13,6 +13,20 @@ logger = logging.getLogger(__name__)
 _TASK_TTL_SECONDS = 7 * 24 * 60 * 60  # 7 days
 
 
+class InvalidTaskTransitionError(Exception):
+    """Raised when a task status transition is not allowed."""
+
+
+# Valid state machine transitions.  A same-status "transition" (e.g.
+# RUNNING → RUNNING) is always allowed as an idempotent no-op.
+_VALID_TRANSITIONS: dict[TaskStatusEnum, set[TaskStatusEnum]] = {
+    TaskStatusEnum.PENDING: {TaskStatusEnum.RUNNING, TaskStatusEnum.FAILED},
+    TaskStatusEnum.RUNNING: {TaskStatusEnum.SUCCESS, TaskStatusEnum.FAILED},
+    TaskStatusEnum.SUCCESS: set(),
+    TaskStatusEnum.FAILED: set(),
+}
+
+
 def _task_key(task_id: str) -> str:
     """Return the Redis key for a task JSON payload."""
 
@@ -65,6 +79,10 @@ async def update_task_status(
     """Update status and timestamps for an existing Task.
 
     If the task does not exist, this is a no-op.
+
+    Raises:
+        InvalidTaskTransitionError: If the requested status transition
+            violates the task state machine.
     """
 
     redis = await get_redis_conn()
@@ -83,7 +101,13 @@ async def update_task_status(
         logger.exception("Failed to decode task JSON for %s during update", task_id)
         return
 
-    if status is not None:
+    if status is not None and status != task.status:
+        allowed = _VALID_TRANSITIONS.get(task.status, set())
+        if status not in allowed:
+            raise InvalidTaskTransitionError(
+                f"Cannot transition task {task_id} from {task.status.value!r} "
+                f"to {status.value!r}"
+            )
         task.status = status
     if started_at is not None:
         task.started_at = started_at

--- a/tests/integration/test_task_transition_guards.py
+++ b/tests/integration/test_task_transition_guards.py
@@ -1,0 +1,118 @@
+"""Test that task status transitions are validated.
+
+Regression tests for https://github.com/redis/agent-memory-server/issues/205
+"""
+
+import pytest
+from ulid import ULID
+
+from agent_memory_server.models import Task, TaskStatusEnum, TaskTypeEnum
+from agent_memory_server.tasks import (
+    InvalidTaskTransitionError,
+    create_task,
+    update_task_status,
+)
+
+
+def _make_task(**overrides) -> Task:
+    defaults = {
+        "id": str(ULID()),
+        "type": TaskTypeEnum.SUMMARY_VIEW_FULL_RUN,
+        "view_id": "test-view",
+    }
+    defaults.update(overrides)
+    return Task(**defaults)
+
+
+class TestTaskTransitionGuards:
+    """update_task_status should reject invalid status transitions."""
+
+    @pytest.mark.asyncio
+    async def test_valid_pending_to_running(self, async_redis_client):
+        task = _make_task(status=TaskStatusEnum.PENDING)
+        await create_task(task)
+        await update_task_status(task.id, status=TaskStatusEnum.RUNNING)
+        # Should not raise
+
+    @pytest.mark.asyncio
+    async def test_valid_pending_to_failed(self, async_redis_client):
+        task = _make_task(status=TaskStatusEnum.PENDING)
+        await create_task(task)
+        await update_task_status(task.id, status=TaskStatusEnum.FAILED)
+
+    @pytest.mark.asyncio
+    async def test_valid_running_to_success(self, async_redis_client):
+        task = _make_task(status=TaskStatusEnum.RUNNING)
+        await create_task(task)
+        await update_task_status(task.id, status=TaskStatusEnum.SUCCESS)
+
+    @pytest.mark.asyncio
+    async def test_valid_running_to_failed(self, async_redis_client):
+        task = _make_task(status=TaskStatusEnum.RUNNING)
+        await create_task(task)
+        await update_task_status(task.id, status=TaskStatusEnum.FAILED)
+
+    @pytest.mark.asyncio
+    async def test_rejects_success_to_running(self, async_redis_client):
+        task = _make_task(status=TaskStatusEnum.SUCCESS)
+        await create_task(task)
+        with pytest.raises(InvalidTaskTransitionError):
+            await update_task_status(task.id, status=TaskStatusEnum.RUNNING)
+
+    @pytest.mark.asyncio
+    async def test_rejects_success_to_pending(self, async_redis_client):
+        task = _make_task(status=TaskStatusEnum.SUCCESS)
+        await create_task(task)
+        with pytest.raises(InvalidTaskTransitionError):
+            await update_task_status(task.id, status=TaskStatusEnum.PENDING)
+
+    @pytest.mark.asyncio
+    async def test_rejects_failed_to_success(self, async_redis_client):
+        task = _make_task(status=TaskStatusEnum.FAILED)
+        await create_task(task)
+        with pytest.raises(InvalidTaskTransitionError):
+            await update_task_status(task.id, status=TaskStatusEnum.SUCCESS)
+
+    @pytest.mark.asyncio
+    async def test_rejects_failed_to_running(self, async_redis_client):
+        task = _make_task(status=TaskStatusEnum.FAILED)
+        await create_task(task)
+        with pytest.raises(InvalidTaskTransitionError):
+            await update_task_status(task.id, status=TaskStatusEnum.RUNNING)
+
+    @pytest.mark.asyncio
+    async def test_rejects_failed_to_pending(self, async_redis_client):
+        task = _make_task(status=TaskStatusEnum.FAILED)
+        await create_task(task)
+        with pytest.raises(InvalidTaskTransitionError):
+            await update_task_status(task.id, status=TaskStatusEnum.PENDING)
+
+    @pytest.mark.asyncio
+    async def test_same_status_update_is_noop(self, async_redis_client):
+        """Updating to the same status should be allowed (idempotent)."""
+        task = _make_task(status=TaskStatusEnum.RUNNING)
+        await create_task(task)
+        await update_task_status(task.id, status=TaskStatusEnum.RUNNING)
+        # Should not raise
+
+    @pytest.mark.asyncio
+    async def test_no_status_change_skips_validation(self, async_redis_client):
+        """When status=None, only other fields are updated — no transition check."""
+        task = _make_task(status=TaskStatusEnum.SUCCESS)
+        await create_task(task)
+        await update_task_status(task.id, error_message="late note")
+        # Should not raise — status wasn't changed
+
+    @pytest.mark.asyncio
+    async def test_invalid_transition_does_not_mutate_task(self, async_redis_client):
+        """A rejected transition should leave the task in its original state."""
+        task = _make_task(status=TaskStatusEnum.SUCCESS)
+        await create_task(task)
+
+        with pytest.raises(InvalidTaskTransitionError):
+            await update_task_status(task.id, status=TaskStatusEnum.RUNNING)
+
+        from agent_memory_server.tasks import get_task
+
+        unchanged = await get_task(task.id)
+        assert unchanged.status == TaskStatusEnum.SUCCESS


### PR DESCRIPTION
## Summary

- Add `InvalidTaskTransitionError` and a `_VALID_TRANSITIONS` state machine to `update_task_status`
- Valid transitions: PENDING→RUNNING, PENDING→FAILED, RUNNING→SUCCESS, RUNNING→FAILED
- Same-status updates are allowed (idempotent no-op)
- Invalid transitions raise `InvalidTaskTransitionError` without mutating the task

## Changes

- `agent_memory_server/tasks.py`: Add transition validation before persisting status changes
- `tests/integration/test_task_transition_guards.py`: 12 tests covering valid transitions, rejected transitions, idempotent updates, and mutation safety

## Test plan

- [x] All 12 new integration tests pass
- [x] Full existing test suite passes (719 passed, 0 failures)

Closes #205

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new exception-throwing behavior in `update_task_status`, which could surface in callers that previously performed out-of-order transitions. Scope is contained to task metadata updates and is covered by new integration tests.
> 
> **Overview**
> **Adds task status transition validation.** `update_task_status` now enforces an explicit state machine (e.g., PENDING→RUNNING/FAILED, RUNNING→SUCCESS/FAILED) and raises `InvalidTaskTransitionError` on illegal transitions while allowing same-status updates as idempotent no-ops.
> 
> **Adds regression coverage.** New integration tests exercise allowed transitions, rejected transitions, and ensure failed updates don’t mutate persisted task state.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 719f5f5de701c7adfc2a946436b22b3b7e3ae07e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->