### PR TITLE
fix: remove unreachable created_at backfill in update_task_status

### DIFF
--- a/agent_memory_server/tasks.py
+++ b/agent_memory_server/tasks.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import UTC, datetime
+from datetime import datetime
 
 from agent_memory_server.models import Task, TaskStatusEnum
 from agent_memory_server.utils.redis import get_redis_conn
@@ -128,9 +128,5 @@ async def update_task_status(
             f"Task {task_id}: started_at ({task.started_at}) must not "
             f"be after completed_at ({task.completed_at})"
         )
-
-    # Ensure created_at is always set
-    if task.created_at is None:
-        task.created_at = datetime.now(UTC)
 
     await redis.set(key, task.model_dump_json(), ex=_TASK_TTL_SECONDS)

--- a/tests/integration/test_task_created_at_invariant.py
+++ b/tests/integration/test_task_created_at_invariant.py
@@ -1,0 +1,92 @@
+"""Test that Task.created_at is always set and never null.
+
+Regression test for https://github.com/redis/agent-memory-server/issues/208
+
+The Task model defines created_at as a non-optional datetime with a
+default_factory, so every task created through the normal API always has
+created_at set.  This test verifies that invariant holds and that the
+previously dead backfill code in update_task_status is no longer needed.
+"""
+
+import json
+from datetime import UTC, datetime
+
+import pytest
+from ulid import ULID
+
+from agent_memory_server.models import Task, TaskStatusEnum, TaskTypeEnum
+from agent_memory_server.tasks import (
+    _task_key,
+    create_task,
+    get_task,
+    update_task_status,
+)
+
+
+def _make_task(**overrides) -> Task:
+    defaults = {
+        "id": str(ULID()),
+        "type": TaskTypeEnum.SUMMARY_VIEW_FULL_RUN,
+        "view_id": "test-view",
+    }
+    defaults.update(overrides)
+    return Task(**defaults)
+
+
+class TestCreatedAtInvariant:
+    """created_at is always set on valid tasks and never null."""
+
+    @pytest.mark.asyncio
+    async def test_created_at_always_populated_on_create(self, async_redis_client):
+        """create_task should always produce a task with created_at set."""
+        before = datetime.now(UTC)
+        task = _make_task()
+        await create_task(task)
+        after = datetime.now(UTC)
+
+        retrieved = await get_task(task.id)
+        assert retrieved.created_at is not None
+        assert before <= retrieved.created_at <= after
+
+    @pytest.mark.asyncio
+    async def test_created_at_preserved_through_updates(self, async_redis_client):
+        """Updating a task should never change its created_at."""
+        task = _make_task()
+        await create_task(task)
+        original = (await get_task(task.id)).created_at
+
+        await update_task_status(task.id, status=TaskStatusEnum.RUNNING)
+        await update_task_status(task.id, status=TaskStatusEnum.SUCCESS)
+
+        final = await get_task(task.id)
+        assert final.created_at == original
+
+    @pytest.mark.asyncio
+    async def test_null_created_at_in_redis_is_unrecoverable(self, async_redis_client):
+        """A task with created_at=null in Redis cannot be parsed by the
+        Task model.  Both get_task and update_task_status treat it as
+        corrupt data (return None / no-op)."""
+        from agent_memory_server.utils.redis import get_redis_conn
+
+        task_id = str(ULID())
+        corrupt_json = json.dumps(
+            {
+                "id": task_id,
+                "type": "summary_view_full_run",
+                "status": "pending",
+                "view_id": None,
+                "created_at": None,
+                "started_at": None,
+                "completed_at": None,
+                "error_message": None,
+            }
+        )
+        redis = await get_redis_conn()
+        await redis.set(_task_key(task_id), corrupt_json, ex=300)
+
+        # get_task returns None — the task is unrecoverable
+        assert await get_task(task_id) is None
+
+        # update_task_status is a no-op — it can't parse the corrupt task
+        await update_task_status(task_id, status=TaskStatusEnum.RUNNING)
+        assert await get_task(task_id) is None


### PR DESCRIPTION
## Summary

- Remove dead backfill code in `update_task_status` that checked `if task.created_at is None`
- `Task.created_at` is a non-optional `datetime` field with `default_factory`, so `model_validate_json` rejects null values before the backfill could execute
- Remove unused `UTC` import

## Changes

- `agent_memory_server/tasks.py`: Remove unreachable lines 95-97, remove unused `UTC` import
- `tests/integration/test_task_created_at_invariant.py`: 3 tests documenting the `created_at` invariant and confirming null values in Redis are treated as corrupt

## Test plan

- [x] All 3 new integration tests pass
- [x] Full existing test suite passes (710 passed, 0 failures)

Closes #208

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes unreachable `created_at` backfill logic and adds integration coverage; runtime behavior only changes in that `update_task_status` no longer mutates tasks on the (already-unparseable) corrupt `created_at=null` case.
> 
> **Overview**
> Removes the unreachable `created_at` backfill in `update_task_status` (and the now-unused `UTC` import), relying on the `Task` model’s non-null `created_at` invariant rather than attempting to patch invalid data at update time.
> 
> Adds an integration regression suite asserting `created_at` is set on `create_task`, preserved across status updates, and that tasks with `created_at=null` stored in Redis are treated as corrupt (i.e., `get_task` returns `None` and `update_task_status` becomes a no-op).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b116912eaa9aaecbad3521dfff2b9e879be74f3f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->