### PR TITLE
chore: Bump server version to 0.14.0

### DIFF
--- a/agent_memory_server/__init__.py
+++ b/agent_memory_server/__init__.py
@@ -1,3 +1,3 @@
 """Redis Agent Memory Server - A memory system for conversational AI."""
 
-__version__ = "0.13.2"
+__version__ = "0.14.0"


### PR DESCRIPTION
## Summary
- bump the agent-memory-server version from `0.13.2` to `0.14.0`

## Validation
- `uv run pytest tests/test_cli.py::TestVersion::test_version_command -q`
- `uv run ruff check agent_memory_server/__init__.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk version-only change; behavior is unchanged aside from reported version in the CLI/API metadata.
> 
> **Overview**
> Bumps the `agent_memory_server` package version from `0.13.2` to `0.14.0`, affecting the version string reported via imports/CLI and FastAPI app metadata.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8a2a253797c1603c05a84f089e802c19a4861762. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->