### PR TITLE
ci: Add workflow for running service tests on forked PRs (closes #197)

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -31,6 +31,40 @@ jobs:
       run: |
         uv run pre-commit run --all-files
 
+  service-tests:
+    name: Service Tests
+    needs: lint
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set Redis image name
+      run: |
+          echo "REDIS_IMAGE=redis:8.6" >> $GITHUB_ENV
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.12'
+        cache: 'pip'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install uv
+        uv sync --all-extras
+
+    - name: Install agent-memory-client
+      run: |
+        uv pip install -e ./agent-memory-client
+
+    - name: Run service tests
+      run: |
+        uv run pytest --run-api-tests
+      env:
+        OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+
   test:
     needs: lint
     runs-on: ubuntu-latest
@@ -65,6 +99,4 @@ jobs:
 
     - name: Run tests
       run: |
-        uv run pytest --run-api-tests
-      env:
-        OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        uv run pytest

--- a/.github/workflows/test-fork-pr.yml
+++ b/.github/workflows/test-fork-pr.yml
@@ -1,0 +1,141 @@
+name: Test Fork PR
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'Pull request number to test'
+        required: true
+        type: number
+
+permissions:
+  contents: read
+  checks: write
+  pull-requests: read
+
+jobs:
+  setup:
+    name: Validate PR
+    runs-on: ubuntu-latest
+    outputs:
+      head_sha: ${{ steps.pr-info.outputs.head_sha }}
+      head_repo: ${{ steps.pr-info.outputs.head_repo }}
+    steps:
+      - name: Get PR information
+        id: pr-info
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: ${{ inputs.pr_number }}
+            });
+
+            if (pr.data.state !== 'open') {
+              core.setFailed(`PR #${{ inputs.pr_number }} is not open`);
+              return;
+            }
+
+            if (pr.data.head.repo.full_name === `${context.repo.owner}/${context.repo.repo}`) {
+              core.setFailed(`PR #${{ inputs.pr_number }} is not from a fork. Use the regular workflow.`);
+              return;
+            }
+
+            core.setOutput('head_sha', pr.data.head.sha);
+            core.setOutput('head_repo', pr.data.head.repo.full_name);
+
+            console.log(`Testing PR #${{ inputs.pr_number }}`);
+            console.log(`  Head SHA: ${pr.data.head.sha}`);
+            console.log(`  Head Repo: ${pr.data.head.repo.full_name}`);
+
+  service-tests:
+    name: Service Tests
+    runs-on: ubuntu-latest
+    needs: setup
+    steps:
+      - name: Create check run
+        id: check
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const check = await github.rest.checks.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: 'Fork PR - Service Tests',
+              head_sha: '${{ needs.setup.outputs.head_sha }}',
+              status: 'in_progress',
+              started_at: new Date().toISOString()
+            });
+            core.setOutput('check_id', check.data.id);
+
+      - name: Check out fork PR code
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ needs.setup.outputs.head_repo }}
+          ref: ${{ needs.setup.outputs.head_sha }}
+
+      - name: Set Redis image name
+        run: |
+          echo "REDIS_IMAGE=redis:8.6" >> $GITHUB_ENV
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install uv
+          uv sync --all-extras
+
+      - name: Install agent-memory-client
+        run: |
+          uv pip install -e ./agent-memory-client
+
+      - name: Run service tests
+        run: |
+          uv run pytest --run-api-tests
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+
+      - name: Update check run (success)
+        if: success()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.checks.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              check_run_id: ${{ steps.check.outputs.check_id }},
+              status: 'completed',
+              conclusion: 'success',
+              completed_at: new Date().toISOString(),
+              details_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              output: {
+                title: 'Service Tests Passed',
+                summary: `All service tests passed for PR #${{ inputs.pr_number }}.`
+              }
+            });
+
+      - name: Update check run (failure)
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.checks.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              check_run_id: ${{ steps.check.outputs.check_id }},
+              status: 'completed',
+              conclusion: 'failure',
+              completed_at: new Date().toISOString(),
+              details_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              output: {
+                title: 'Service Tests Failed',
+                summary: `The service tests failed for PR #${{ inputs.pr_number }}. Click "Details" to view the full test output and logs.`,
+                text: `**Workflow Run:** [View Details](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})\n\n**PR:** #${{ inputs.pr_number }}\n**Commit:** ${{ needs.setup.outputs.head_sha }}`
+              }
+            });


### PR DESCRIPTION
> closes #197 

This PR adds a GitHub actions workflow for running service tests on pull requests from forked repositories. The process for maintainers to follow is:

1. A PR from a forked repository is made
1. A maintainer reviews the PR's code and confirms there's nothing in there that could try to nap secrets during a testing workflow
1. The reviewer clicks the button on the PR view to "Approve workflows to run"; the linters and basic tests will start to run.
1. The reviewer then goes to [the Actions tab, to the "Test Fork PR" workflow](https://github.com/redis/agent-memory-server/actions), where they can click "Run workflow" and enter the PR number. Starting this will run our in-depth service tests on the PR.
1. The workflow will add a status check to the PR, which will resolve to a pass if all service tests pass, or a fail if not (in which case the status check description will include a link to the workflow results with the failed tests).

> Note: If service tests fail, or the contributor makes additional commits, the service test workflow needs to be manually triggered again. I have a TODO to look into automating this process even further - the ideal state is that it's all taken care of once you click "Approve workflows to run".

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes CI execution paths and introduces a new workflow that checks out fork code while using repository secrets, so misconfiguration could expose secrets or produce misleading status checks.
> 
> **Overview**
> Adds a separate **Service Tests** job to `python-tests.yml` that runs `pytest --run-api-tests` only for pushes and same-repo PRs, while the existing matrix `test` job now runs `pytest` without the API/service test flag.
> 
> Introduces a new manually triggered `Test Fork PR` workflow (`workflow_dispatch`) that validates the PR is an open fork, checks out the fork’s head SHA, runs the service tests with `OPENAI_API_KEY`, and reports results back to the PR via a dedicated GitHub Check Run.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eb298f86a4d980c5bd6f60d225e89b3e38943aa6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->