### PR TITLE
fix(notebook): improve memory_prompt demo and fix memory count display

### DIFF
--- a/examples/agent_memory_server_interactive_guide.ipynb
+++ b/examples/agent_memory_server_interactive_guide.ipynb
@@ -80,9 +80,11 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-02-05T01:32:37.844137Z",
-     "start_time": "2026-02-05T01:32:37.780429Z"
+    "execution": {
+     "iopub.execute_input": "2026-03-23T16:01:37.835898Z",
+     "iopub.status.busy": "2026-03-23T16:01:37.835674Z",
+     "iopub.status.idle": "2026-03-23T16:01:37.904399Z",
+     "shell.execute_reply": "2026-03-23T16:01:37.904021Z"
     }
    },
    "outputs": [
@@ -122,9 +124,11 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-02-05T01:32:37.922210Z",
-     "start_time": "2026-02-05T01:32:37.852353Z"
+    "execution": {
+     "iopub.execute_input": "2026-03-23T16:01:37.921316Z",
+     "iopub.status.busy": "2026-03-23T16:01:37.921203Z",
+     "iopub.status.idle": "2026-03-23T16:01:37.960731Z",
+     "shell.execute_reply": "2026-03-23T16:01:37.960340Z"
     }
    },
    "outputs": [
@@ -133,7 +137,7 @@
      "output_type": "stream",
      "text": [
       "Server is healthy!\n",
-      "Server timestamp: 2026-02-05 10:10:41.230000\n"
+      "Server timestamp: 2026-03-23 12:01:37.958000\n"
      ]
     }
    ],
@@ -152,11 +156,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-02-05T01:32:38.994520Z",
-     "start_time": "2026-02-05T01:32:38.906994Z"
+    "execution": {
+     "iopub.execute_input": "2026-03-23T16:01:37.962116Z",
+     "iopub.status.busy": "2026-03-23T16:01:37.962046Z",
+     "iopub.status.idle": "2026-03-23T16:01:38.031724Z",
+     "shell.execute_reply": "2026-03-23T16:01:38.031245Z"
     }
    },
    "outputs": [
@@ -314,11 +320,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-02-05T01:33:46.893490Z",
-     "start_time": "2026-02-05T01:33:46.872796Z"
+    "execution": {
+     "iopub.execute_input": "2026-03-23T16:01:38.032925Z",
+     "iopub.status.busy": "2026-03-23T16:01:38.032854Z",
+     "iopub.status.idle": "2026-03-23T16:01:38.051048Z",
+     "shell.execute_reply": "2026-03-23T16:01:38.050654Z"
     }
    },
    "outputs": [
@@ -361,11 +369,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-02-05T01:34:09.496752Z",
-     "start_time": "2026-02-05T01:34:09.460167Z"
+    "execution": {
+     "iopub.execute_input": "2026-03-23T16:01:38.052261Z",
+     "iopub.status.busy": "2026-03-23T16:01:38.052188Z",
+     "iopub.status.idle": "2026-03-23T16:01:38.060639Z",
+     "shell.execute_reply": "2026-03-23T16:01:38.060299Z"
     }
    },
    "outputs": [
@@ -514,11 +524,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-02-05T01:41:17.831397Z",
-     "start_time": "2026-02-05T01:41:17.814876Z"
+    "execution": {
+     "iopub.execute_input": "2026-03-23T16:01:38.061899Z",
+     "iopub.status.busy": "2026-03-23T16:01:38.061832Z",
+     "iopub.status.idle": "2026-03-23T16:01:38.065346Z",
+     "shell.execute_reply": "2026-03-23T16:01:38.065038Z"
     }
    },
    "outputs": [
@@ -603,11 +615,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-02-05T01:42:57.853204Z",
-     "start_time": "2026-02-05T01:42:55.573850Z"
+    "execution": {
+     "iopub.execute_input": "2026-03-23T16:01:38.066605Z",
+     "iopub.status.busy": "2026-03-23T16:01:38.066527Z",
+     "iopub.status.idle": "2026-03-23T16:01:41.401531Z",
+     "shell.execute_reply": "2026-03-23T16:01:41.400802Z"
     }
    },
    "outputs": [
@@ -615,7 +629,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Query: 'I'm planning a trip to Japan. What should I know about my preferences?'\n",
+      "Query: 'What are my travel preferences?'\n",
       "Searching memories for user: nitin\n",
       "\n"
      ]
@@ -624,9 +638,9 @@
    "source": [
     "\n",
     "import time\n",
-    "time.sleep(2)  # Wait for indexing (memories need to be embedded)\n",
+    "time.sleep(3)  # Wait for indexing (memories need to be embedded)\n",
     "\n",
-    "user_query = \"I'm planning a trip to Japan. What should I know about my preferences?\"\n",
+    "user_query = \"What are my travel preferences?\"\n",
     "\n",
     "print(f\"Query: '{user_query}'\")\n",
     "print(f\"Searching memories for user: {USER_ID}\\n\")\n",
@@ -641,7 +655,8 @@
     "    user_id=USER_ID,\n",
     "    long_term_search={\n",
     "        \"limit\": 5,\n",
-    "        \"distance_threshold\": 0.7,\n",
+    "        # distance_threshold: Lower = stricter. Default ~0.8.\n",
+    "        # Omitting uses server default for broader recall.\n",
     "        \"user_id\": {\"eq\": USER_ID}  # Only search Nitin's memories\n",
     "    }\n",
     ")\n",
@@ -651,11 +666,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-02-05T01:42:57.877113Z",
-     "start_time": "2026-02-05T01:42:57.855968Z"
+    "execution": {
+     "iopub.execute_input": "2026-03-23T16:01:41.404260Z",
+     "iopub.status.busy": "2026-03-23T16:01:41.404075Z",
+     "iopub.status.idle": "2026-03-23T16:01:41.410714Z",
+     "shell.execute_reply": "2026-03-23T16:01:41.410105Z"
     }
    },
    "outputs": [
@@ -664,17 +681,122 @@
       "text/plain": [
        "{'messages': [{'role': 'system',\n",
        "   'content': {'type': 'text',\n",
-       "    'text': \"## Long term memories related to the user's query\\n - Prefers hotels with good amenities (ID: 01KGQ65EQJ3YQ0HJ6PJ9AT3Y4C)\\n- Comfort travel - middle tier (not luxury, not budget) (ID: 01KGQ65EQHP04EFHB65YZ536ED)\",\n",
+       "    'text': \"## Long term memories related to the user's query\\n - Comfort travel - middle tier (not luxury, not budget) (ID: 01KMDPWARE1HGVH92M3WVG89G7)\\n- Prefers hotels with good amenities (ID: 01KMDPWARE1HGVH92M3WVG89GA)\\n- Extra leg room on flights (premium economy or exit row and budget allows, anything goes) (ID: 01KMDPWARE1HGVH92M3WVG89G9)\\n- Enjoys technology, sports, outdoords, and innovation hubs (ID: 01KMDPWARE1HGVH92M3WVG89GB)\\n- Vegetarian diet - needs vegetarian restaurant options (ID: 01KMDPWARE1HGVH92M3WVG89G8)\",\n",
        "    'annotations': None,\n",
        "    '_meta': None}},\n",
        "  {'role': 'user',\n",
        "   'content': {'type': 'text',\n",
-       "    'text': \"I'm planning a trip to Japan. What should I know about my preferences?\",\n",
+       "    'text': 'What are my travel preferences?',\n",
        "    'annotations': None,\n",
-       "    '_meta': None}}]}"
+       "    '_meta': None}}],\n",
+       " 'long_term_memories': [{'id': '01KMDPWARE1HGVH92M3WVG89G7',\n",
+       "   'text': 'Comfort travel - middle tier (not luxury, not budget)',\n",
+       "   'session_id': None,\n",
+       "   'user_id': 'nitin',\n",
+       "   'namespace': 'travel_agent',\n",
+       "   'last_accessed': '2026-03-23T16:01:38.060000Z',\n",
+       "   'created_at': '2026-03-23T16:01:38.060000Z',\n",
+       "   'updated_at': '2026-03-23T16:01:38.060000Z',\n",
+       "   'pinned': False,\n",
+       "   'access_count': 0,\n",
+       "   'topics': ['travel', 'preferences'],\n",
+       "   'entities': [],\n",
+       "   'memory_hash': '32702233bbeefd16bee2def9a3b2a8e39f4d82859dcfbf09e6770cd67eac5063',\n",
+       "   'discrete_memory_extracted': 'f',\n",
+       "   'memory_type': 'semantic',\n",
+       "   'persisted_at': None,\n",
+       "   'extracted_from': [],\n",
+       "   'event_date': None,\n",
+       "   'extraction_strategy': 'discrete',\n",
+       "   'extraction_strategy_config': {},\n",
+       "   'dist': 0.471005260944},\n",
+       "  {'id': '01KMDPWARE1HGVH92M3WVG89GA',\n",
+       "   'text': 'Prefers hotels with good amenities',\n",
+       "   'session_id': None,\n",
+       "   'user_id': 'nitin',\n",
+       "   'namespace': 'travel_agent',\n",
+       "   'last_accessed': '2026-03-23T16:01:38.060000Z',\n",
+       "   'created_at': '2026-03-23T16:01:38.060000Z',\n",
+       "   'updated_at': '2026-03-23T16:01:38.060000Z',\n",
+       "   'pinned': False,\n",
+       "   'access_count': 0,\n",
+       "   'topics': ['travel', 'preferences'],\n",
+       "   'entities': [],\n",
+       "   'memory_hash': '91ff81a2fc5ec3cb16de824559f41f453d3cf600fce75dc023c325b86b0c8e61',\n",
+       "   'discrete_memory_extracted': 'f',\n",
+       "   'memory_type': 'semantic',\n",
+       "   'persisted_at': None,\n",
+       "   'extracted_from': [],\n",
+       "   'event_date': None,\n",
+       "   'extraction_strategy': 'discrete',\n",
+       "   'extraction_strategy_config': {},\n",
+       "   'dist': 0.545639336109},\n",
+       "  {'id': '01KMDPWARE1HGVH92M3WVG89G9',\n",
+       "   'text': 'Extra leg room on flights (premium economy or exit row and budget allows, anything goes)',\n",
+       "   'session_id': None,\n",
+       "   'user_id': 'nitin',\n",
+       "   'namespace': 'travel_agent',\n",
+       "   'last_accessed': '2026-03-23T16:01:38.060000Z',\n",
+       "   'created_at': '2026-03-23T16:01:38.060000Z',\n",
+       "   'updated_at': '2026-03-23T16:01:38.060000Z',\n",
+       "   'pinned': False,\n",
+       "   'access_count': 0,\n",
+       "   'topics': ['travel', 'preferences'],\n",
+       "   'entities': [],\n",
+       "   'memory_hash': 'ca01af7018684b73f6e8749be087ff2c576d55b683d5664564ccbd7d90c38ad4',\n",
+       "   'discrete_memory_extracted': 'f',\n",
+       "   'memory_type': 'semantic',\n",
+       "   'persisted_at': None,\n",
+       "   'extracted_from': [],\n",
+       "   'event_date': None,\n",
+       "   'extraction_strategy': 'discrete',\n",
+       "   'extraction_strategy_config': {},\n",
+       "   'dist': 0.600184798241},\n",
+       "  {'id': '01KMDPWARE1HGVH92M3WVG89GB',\n",
+       "   'text': 'Enjoys technology, sports, outdoords, and innovation hubs',\n",
+       "   'session_id': None,\n",
+       "   'user_id': 'nitin',\n",
+       "   'namespace': 'travel_agent',\n",
+       "   'last_accessed': '2026-03-23T16:01:38.060000Z',\n",
+       "   'created_at': '2026-03-23T16:01:38.060000Z',\n",
+       "   'updated_at': '2026-03-23T16:01:38.060000Z',\n",
+       "   'pinned': False,\n",
+       "   'access_count': 0,\n",
+       "   'topics': ['travel', 'preferences'],\n",
+       "   'entities': [],\n",
+       "   'memory_hash': 'ecd19b230ba04a08fe8369c3d5d32616b480622b5e2048d3873c14036e831935',\n",
+       "   'discrete_memory_extracted': 'f',\n",
+       "   'memory_type': 'semantic',\n",
+       "   'persisted_at': None,\n",
+       "   'extracted_from': [],\n",
+       "   'event_date': None,\n",
+       "   'extraction_strategy': 'discrete',\n",
+       "   'extraction_strategy_config': {},\n",
+       "   'dist': 0.630759060383},\n",
+       "  {'id': '01KMDPWARE1HGVH92M3WVG89G8',\n",
+       "   'text': 'Vegetarian diet - needs vegetarian restaurant options',\n",
+       "   'session_id': None,\n",
+       "   'user_id': 'nitin',\n",
+       "   'namespace': 'travel_agent',\n",
+       "   'last_accessed': '2026-03-23T16:01:38.060000Z',\n",
+       "   'created_at': '2026-03-23T16:01:38.060000Z',\n",
+       "   'updated_at': '2026-03-23T16:01:38.060000Z',\n",
+       "   'pinned': False,\n",
+       "   'access_count': 0,\n",
+       "   'topics': ['travel', 'preferences'],\n",
+       "   'entities': [],\n",
+       "   'memory_hash': '37e431bf769d345a6ddf90a26c07737c333eb6befbb4015c04f0caec6820904e',\n",
+       "   'discrete_memory_extracted': 'f',\n",
+       "   'memory_type': 'semantic',\n",
+       "   'persisted_at': None,\n",
+       "   'extracted_from': [],\n",
+       "   'event_date': None,\n",
+       "   'extraction_strategy': 'discrete',\n",
+       "   'extraction_strategy_config': {},\n",
+       "   'dist': 0.742618083954}]}"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -685,11 +807,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-02-05T01:45:04.173579Z",
-     "start_time": "2026-02-05T01:45:04.149112Z"
+    "execution": {
+     "iopub.execute_input": "2026-03-23T16:01:41.412924Z",
+     "iopub.status.busy": "2026-03-23T16:01:41.412785Z",
+     "iopub.status.idle": "2026-03-23T16:01:41.417766Z",
+     "shell.execute_reply": "2026-03-23T16:01:41.417325Z"
     }
    },
    "outputs": [
@@ -701,15 +825,18 @@
       "MEMORY PROMPT RESULT\n",
       "============================================================\n",
       "Messages in context: 2\n",
-      "Long-term memories found: 1\n",
+      "Long-term memories found: 5\n",
       "\n",
       "[SYSTEM]\n",
       "## Long term memories related to the user's query\n",
-      " - Prefers hotels with good amenities (ID: 01KGQ65EQJ3YQ0HJ6PJ9AT3Y4C)\n",
-      "- Comfort travel - middle tier (not luxury, not budget) (ID: 01KGQ65EQHP04EFHB65YZ536ED)\n",
+      " - Comfort travel - middle tier (not luxury, not budget) (ID: 01KMDPWARE1HGVH92M3WVG89G7)\n",
+      "- Prefers hotels with good amenities (ID: 01KMDPWARE1HGVH92M3WVG89GA)\n",
+      "- Extra leg room on flights (premium economy or exit row and budget allows, anything goes) (ID: 01KMDPWARE1HGVH92M3WVG89G9)\n",
+      "- Enjoys technology, sports, outdoords, and innovation hubs (ID: 01KMDPWARE1HGVH92M3WVG89GB)\n",
+      "- Vegetarian diet - needs vegetarian restaurant options (ID: 01KMDPWARE1HGVH92M3WVG89G8)\n",
       "\n",
       "[USER]\n",
-      "I'm planning a trip to Japan. What should I know about my preferences?\n",
+      "What are my travel preferences?\n",
       "\n"
      ]
     },
@@ -718,17 +845,17 @@
       "text/plain": [
        "[{'role': 'system',\n",
        "  'content': {'type': 'text',\n",
-       "   'text': \"## Long term memories related to the user's query\\n - Prefers hotels with good amenities (ID: 01KGQ65EQJ3YQ0HJ6PJ9AT3Y4C)\\n- Comfort travel - middle tier (not luxury, not budget) (ID: 01KGQ65EQHP04EFHB65YZ536ED)\",\n",
+       "   'text': \"## Long term memories related to the user's query\\n - Comfort travel - middle tier (not luxury, not budget) (ID: 01KMDPWARE1HGVH92M3WVG89G7)\\n- Prefers hotels with good amenities (ID: 01KMDPWARE1HGVH92M3WVG89GA)\\n- Extra leg room on flights (premium economy or exit row and budget allows, anything goes) (ID: 01KMDPWARE1HGVH92M3WVG89G9)\\n- Enjoys technology, sports, outdoords, and innovation hubs (ID: 01KMDPWARE1HGVH92M3WVG89GB)\\n- Vegetarian diet - needs vegetarian restaurant options (ID: 01KMDPWARE1HGVH92M3WVG89G8)\",\n",
        "   'annotations': None,\n",
        "   '_meta': None}},\n",
        " {'role': 'user',\n",
        "  'content': {'type': 'text',\n",
-       "   'text': \"I'm planning a trip to Japan. What should I know about my preferences?\",\n",
+       "   'text': 'What are my travel preferences?',\n",
        "   'annotations': None,\n",
        "   '_meta': None}}]"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -743,7 +870,7 @@
     "\n",
     "# Count long-term memories from the system message\n",
     "# The memory_prompt() API embeds memories directly in the system message text\n",
-    "# Each memory line starts with \" - \" (space-dash-space)\n",
+    "# Each memory entry is on its own line starting with \"-\" or \" -\"\n",
     "memory_count = 0\n",
     "for msg in messages:\n",
     "    if msg.get(\"role\") == \"system\":\n",
@@ -752,8 +879,8 @@
     "            text = content.get(\"text\", \"\")\n",
     "        else:\n",
     "            text = str(content)\n",
-    "        # Count lines that start with \" - \" (memory entries)\n",
-    "        memory_count = text.count(\"\\n - \") + (1 if text.strip().startswith(\"- \") else 0)\n",
+    "        # Count lines that contain memory IDs (format: \"(ID: XXXX)\")\n",
+    "        memory_count = text.count(\"(ID:\")\n",
     "        break\n",
     "\n",
     "print(f\"Long-term memories found: {memory_count}\")\n",
@@ -776,12 +903,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-02-05T01:45:59.287102Z",
-     "start_time": "2026-02-05T01:45:59.258888Z"
-    }
-   },
+   "metadata": {},
    "source": [
     "### Step 4: Store conversation in working memory\n",
     "\n",
@@ -791,21 +913,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-02-05T01:46:38.160818Z",
-     "start_time": "2026-02-05T01:46:38.123197Z"
+    "execution": {
+     "iopub.execute_input": "2026-03-23T16:01:41.419294Z",
+     "iopub.status.busy": "2026-03-23T16:01:41.419175Z",
+     "iopub.status.idle": "2026-03-23T16:01:41.492334Z",
+     "shell.execute_reply": "2026-03-23T16:01:41.491932Z"
     }
    },
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "MemoryMessage created without explicit created_at timestamp. This will become required in a future version. Please provide created_at for accurate message ordering.\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -817,10 +934,10 @@
     {
      "data": {
       "text/plain": [
-       "WorkingMemoryResponse(messages=[MemoryMessage(role='user', content=\"I'm planning a trip to Japan next month!\", id='01KGQ6F7Q3AB0GHS96FG254WGC', created_at=datetime.datetime(2026, 2, 5, 15, 24, 28, 771507, tzinfo=TzInfo(0)), persisted_at=None, discrete_memory_extracted='f'), MemoryMessage(role='assistant', content='Exciting! Based on your preferences, I know you enjoy hiking and vegetarian food. Japan has amazing options for both!', id='01KGQ6F7Q3AB0GHS96FG254WGD', created_at=datetime.datetime(2026, 2, 5, 15, 24, 28, 771539, tzinfo=TzInfo(0)), persisted_at=None, discrete_memory_extracted='f'), MemoryMessage(role='user', content=\"Yes! I'd love to hike Mount Fuji and find good vegetarian ramen.\", id='01KGQ6F7Q3AB0GHS96FG254WGE', created_at=datetime.datetime(2026, 2, 5, 15, 24, 28, 771553, tzinfo=TzInfo(0)), persisted_at=None, discrete_memory_extracted='f'), MemoryMessage(role='assistant', content=\"Perfect! I'll remember your interest in Mount Fuji. For vegetarian ramen, Kyoto has excellent options.\", id='01KGQ6F7Q3AB0GHS96FG254WGF', created_at=datetime.datetime(2026, 2, 5, 15, 24, 28, 771565, tzinfo=TzInfo(0)), persisted_at=None, discrete_memory_extracted='f')], memories=[], data=None, context=None, user_id='nitin', tokens=0, session_id='nitin-travel-session-2', namespace='travel_agent', long_term_memory_strategy=MemoryStrategyConfig(strategy='discrete', config={}), ttl_seconds=None, last_accessed=datetime.datetime(2026, 2, 5, 15, 24, 28, 771649, tzinfo=TzInfo(0)), context_percentage_total_used=None, context_percentage_until_summarization=None, new_session=None, unsaved=None)"
+       "WorkingMemoryResponse(messages=[MemoryMessage(role='user', content=\"I'm planning a trip to Japan next month!\", id='01KMDPWE1CVFQKF8XQDHBFKRSS', created_at=datetime.datetime(2026, 3, 23, 16, 1, 41, 420271, tzinfo=TzInfo(0)), persisted_at=None, discrete_memory_extracted='f'), MemoryMessage(role='assistant', content='Exciting! Based on your preferences, I know you enjoy hiking and vegetarian food. Japan has amazing options for both!', id='01KMDPWE1CVFQKF8XQDHBFKRST', created_at=datetime.datetime(2026, 3, 23, 16, 1, 41, 420352, tzinfo=TzInfo(0)), persisted_at=None, discrete_memory_extracted='f'), MemoryMessage(role='user', content=\"Yes! I'd love to hike Mount Fuji and find good vegetarian ramen.\", id='01KMDPWE1CVFQKF8XQDHBFKRSV', created_at=datetime.datetime(2026, 3, 23, 16, 1, 41, 420368, tzinfo=TzInfo(0)), persisted_at=None, discrete_memory_extracted='f'), MemoryMessage(role='assistant', content=\"Perfect! I'll remember your interest in Mount Fuji. For vegetarian ramen, Kyoto has excellent options.\", id='01KMDPWE1CVFQKF8XQDHBFKRSW', created_at=datetime.datetime(2026, 3, 23, 16, 1, 41, 420378, tzinfo=TzInfo(0)), persisted_at=None, discrete_memory_extracted='f')], memories=[], data=None, context=None, user_id='nitin', tokens=0, session_id='nitin-travel-session-2', namespace='travel_agent', long_term_memory_strategy=MemoryStrategyConfig(strategy='discrete', config={}), ttl_seconds=None, last_accessed=datetime.datetime(2026, 3, 23, 16, 1, 41, 420443, tzinfo=TzInfo(0)), context_percentage_total_used=None, context_percentage_until_summarization=None, new_session=None, unsaved=None)"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -828,10 +945,10 @@
    "source": [
     "\n",
     "messages = [\n",
-    "    MemoryMessage(role=\"user\", content=\"I'm planning a trip to Japan next month!\"),\n",
-    "    MemoryMessage(role=\"assistant\", content=\"Exciting! Based on your preferences, I know you enjoy hiking and vegetarian food. Japan has amazing options for both!\"),\n",
-    "    MemoryMessage(role=\"user\", content=\"Yes! I'd love to hike Mount Fuji and find good vegetarian ramen.\"),\n",
-    "    MemoryMessage(role=\"assistant\", content=\"Perfect! I'll remember your interest in Mount Fuji. For vegetarian ramen, Kyoto has excellent options.\")\n",
+    "    MemoryMessage(role=\"user\", content=\"I'm planning a trip to Japan next month!\", created_at=datetime.now(timezone.utc)),\n",
+    "    MemoryMessage(role=\"assistant\", content=\"Exciting! Based on your preferences, I know you enjoy hiking and vegetarian food. Japan has amazing options for both!\", created_at=datetime.now(timezone.utc)),\n",
+    "    MemoryMessage(role=\"user\", content=\"Yes! I'd love to hike Mount Fuji and find good vegetarian ramen.\", created_at=datetime.now(timezone.utc)),\n",
+    "    MemoryMessage(role=\"assistant\", content=\"Perfect! I'll remember your interest in Mount Fuji. For vegetarian ramen, Kyoto has excellent options.\", created_at=datetime.now(timezone.utc))\n",
     "]\n",
     "\n",
     "updated_memory = WorkingMemory(\n",
@@ -849,16 +966,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
-   "metadata": {},
+   "execution_count": 11,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-23T16:01:41.493649Z",
+     "iopub.status.busy": "2026-03-23T16:01:41.493553Z",
+     "iopub.status.idle": "2026-03-23T16:01:41.495659Z",
+     "shell.execute_reply": "2026-03-23T16:01:41.495261Z"
+    }
+   },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "MemoryMessage(role='assistant', content=\"Perfect! I'll remember your interest in Mount Fuji. For vegetarian ramen, Kyoto has excellent options.\", id='01KGQ6F7Q3AB0GHS96FG254WGF', created_at=datetime.datetime(2026, 2, 5, 15, 24, 28, 771565, tzinfo=TzInfo(0)), persisted_at=None, discrete_memory_extracted='f')"
+       "MemoryMessage(role='assistant', content=\"Perfect! I'll remember your interest in Mount Fuji. For vegetarian ramen, Kyoto has excellent options.\", id='01KMDPWE1CVFQKF8XQDHBFKRSW', created_at=datetime.datetime(2026, 3, 23, 16, 1, 41, 420378, tzinfo=TzInfo(0)), persisted_at=None, discrete_memory_extracted='f')"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -869,11 +993,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 12,
    "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-02-05T01:52:49.834941Z",
-     "start_time": "2026-02-05T01:52:49.629731Z"
+    "execution": {
+     "iopub.execute_input": "2026-03-23T16:01:41.496754Z",
+     "iopub.status.busy": "2026-03-23T16:01:41.496663Z",
+     "iopub.status.idle": "2026-03-23T16:01:41.791921Z",
+     "shell.execute_reply": "2026-03-23T16:01:41.790753Z"
     }
    },
    "outputs": [
@@ -882,61 +1008,37 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "Found 9 memories:\n",
+      "Found 5 memories:\n",
       "\n",
       "1. [48% relevant]\n",
-      "   ID: 01KGQ65EQHP04EFHB65YZ536ED\n",
+      "   ID: 01KMDPWARE1HGVH92M3WVG89G7\n",
       "   Text: Comfort travel - middle tier (not luxury, not budget)\n",
       "   Topics: ['travel', 'preferences']\n",
-      "   Created: 2026-02-05 15:19:08.273890+00:00\n",
+      "   Created: 2026-03-23 16:01:38.060000+00:00\n",
       "\n",
       "2. [41% relevant]\n",
-      "   ID: 01KGQ65EQJ3YQ0HJ6PJ9AT3Y4B\n",
+      "   ID: 01KMDPWARE1HGVH92M3WVG89G9\n",
       "   Text: Extra leg room on flights (premium economy or exit row and budget allows, anything goes)\n",
       "   Topics: ['travel', 'preferences']\n",
-      "   Created: 2026-02-05 15:19:08.274876+00:00\n",
+      "   Created: 2026-03-23 16:01:38.060000+00:00\n",
       "\n",
       "3. [37% relevant]\n",
-      "   ID: 01KGQ65EQJ3YQ0HJ6PJ9AT3Y4C\n",
+      "   ID: 01KMDPWARE1HGVH92M3WVG89GA\n",
       "   Text: Prefers hotels with good amenities\n",
       "   Topics: ['travel', 'preferences']\n",
-      "   Created: 2026-02-05 15:19:08.274893+00:00\n",
+      "   Created: 2026-03-23 16:01:38.060000+00:00\n",
       "\n",
-      "4. [34% relevant]\n",
-      "   ID: 01KGQ6FE0809B98WPX0V0AAY5J\n",
-      "   Text: User enjoys hiking and vegetarian food\n",
-      "   Topics: ['travel', 'food', 'hiking']\n",
-      "   Created: 2026-02-05 15:24:35.208709+00:00\n",
-      "\n",
-      "5. [33% relevant]\n",
-      "   ID: 01KGQ6FE0809B98WPX0V0AAY5K\n",
-      "   Text: User is planning a trip to Japan in March 2026\n",
-      "   Topics: ['travel', 'Japan']\n",
-      "   Created: 2026-02-05 15:24:35.208786+00:00\n",
-      "\n",
-      "6. [31% relevant]\n",
-      "   ID: 01KGQ65EQJ3YQ0HJ6PJ9AT3Y4D\n",
+      "4. [31% relevant]\n",
+      "   ID: 01KMDPWARE1HGVH92M3WVG89GB\n",
       "   Text: Enjoys technology, sports, outdoords, and innovation hubs\n",
       "   Topics: ['travel', 'preferences']\n",
-      "   Created: 2026-02-05 15:19:08.274909+00:00\n",
+      "   Created: 2026-03-23 16:01:38.060000+00:00\n",
       "\n",
-      "7. [30% relevant]\n",
-      "   ID: 01KGQ6FE0809B98WPX0V0AAY5M\n",
-      "   Text: User would love to hike Mount Fuji during the trip to Japan\n",
-      "   Topics: ['travel', 'hiking', 'Mount Fuji']\n",
-      "   Created: 2026-02-05 15:24:35.208808+00:00\n",
-      "\n",
-      "8. [25% relevant]\n",
-      "   ID: 01KGQ65EQJ3YQ0HJ6PJ9AT3Y4A\n",
+      "5. [25% relevant]\n",
+      "   ID: 01KMDPWARE1HGVH92M3WVG89G8\n",
       "   Text: Vegetarian diet - needs vegetarian restaurant options\n",
       "   Topics: ['travel', 'preferences']\n",
-      "   Created: 2026-02-05 15:19:08.274842+00:00\n",
-      "\n",
-      "9. [23% relevant]\n",
-      "   ID: 01KGQ6FE0809B98WPX0V0AAY5N\n",
-      "   Text: User is interested in finding good vegetarian ramen while in Japan\n",
-      "   Topics: ['travel', 'food', 'ramen']\n",
-      "   Created: 2026-02-05 15:24:35.208823+00:00\n",
+      "   Created: 2026-03-23 16:01:38.060000+00:00\n",
       "\n"
      ]
     }
@@ -992,7 +1094,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "bb---\n",
+    "---\n",
     "\n",
     "## Section 5: Pattern 2 - LLM-Driven (Tool-Based)\n",
     "\n",
@@ -1031,11 +1133,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 13,
    "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-02-05T01:55:47.402051Z",
-     "start_time": "2026-02-05T01:55:47.379380Z"
+    "execution": {
+     "iopub.execute_input": "2026-03-23T16:01:41.794117Z",
+     "iopub.status.busy": "2026-03-23T16:01:41.793949Z",
+     "iopub.status.idle": "2026-03-23T16:01:41.797043Z",
+     "shell.execute_reply": "2026-03-23T16:01:41.796582Z"
     }
    },
    "outputs": [
@@ -1084,22 +1188,19 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-02-05T01:56:24.785448Z",
-     "start_time": "2026-02-05T01:56:24.777996Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 14,
    "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-02-05T01:57:31.693234Z",
-     "start_time": "2026-02-05T01:57:31.532409Z"
+    "execution": {
+     "iopub.execute_input": "2026-03-23T16:01:41.798862Z",
+     "iopub.status.busy": "2026-03-23T16:01:41.798760Z",
+     "iopub.status.idle": "2026-03-23T16:01:41.960247Z",
+     "shell.execute_reply": "2026-03-23T16:01:41.959896Z"
     }
    },
    "outputs": [
@@ -1137,12 +1238,12 @@
     "# System prompt that encourages memory usage\n",
     "system_prompt = \"\"\"You are a helpful assistant with persistent memory capabilities.\n",
     "\n",
-    "When to remember (use create_long_term_memories tool):\n",
+    "When to remember (use eagerly_create_long_term_memory tool):\n",
     "- User preferences (food, communication style, etc.)\n",
     "- Important personal information\n",
     "- Project details and context\n",
     "\n",
-    "When to search memory (use search_long_term_memory tool):\n",
+    "When to search memory (use search_memory tool):\n",
     "- User asks about previous conversations\n",
     "- Context would help provide better responses\n",
     "- User references something from the past\n",
@@ -1157,11 +1258,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 15,
    "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-02-05T01:59:12.533403Z",
-     "start_time": "2026-02-05T01:59:10.879687Z"
+    "execution": {
+     "iopub.execute_input": "2026-03-23T16:01:41.961588Z",
+     "iopub.status.busy": "2026-03-23T16:01:41.961521Z",
+     "iopub.status.idle": "2026-03-23T16:01:44.061285Z",
+     "shell.execute_reply": "2026-03-23T16:01:44.060708Z"
     }
    },
    "outputs": [
@@ -1171,7 +1274,7 @@
      "text": [
       "LLM decided to use 1 tool(s):\n",
       "  - lazily_create_long_term_memory\n",
-      "    Args: {\"text\":\"User's name is Nitin and is planning a trip to Tokyo.\",\"memory_type\":\"semantic\",\"topics\":[\"travel\"],\"entities\":[\"Tokyo\"]}\n"
+      "    Args: {\"text\":\"User is planning a trip to Tokyo and is looking for vegetarian restaurants.\",\"memory_type\":\"semantic\",\"topics\":[\"travel\",\"preferences\"],\"entities\":[\"Tokyo\",\"vegetarian\",\"restaurants\"]}\n"
      ]
     }
    ],
@@ -1202,11 +1305,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 16,
    "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-02-05T02:00:26.275794Z",
-     "start_time": "2026-02-05T02:00:26.224405Z"
+    "execution": {
+     "iopub.execute_input": "2026-03-23T16:01:44.063059Z",
+     "iopub.status.busy": "2026-03-23T16:01:44.062910Z",
+     "iopub.status.idle": "2026-03-23T16:01:44.080997Z",
+     "shell.execute_reply": "2026-03-23T16:01:44.080177Z"
     }
    },
    "outputs": [
@@ -1216,7 +1321,7 @@
      "text": [
       "\n",
       "Executing: lazily_create_long_term_memory\n",
-      "  Result: Successfully stored semantic memory: User's name is Nitin and is planning a trip to Tok...\n",
+      "  Result: Successfully stored semantic memory: User is planning a trip to Tokyo and is looking fo...\n",
       "\n",
       "Executed 1 tool call(s)\n"
      ]
@@ -1254,11 +1359,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 17,
    "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-02-05T02:01:24.838828Z",
-     "start_time": "2026-02-05T02:01:24.814685Z"
+    "execution": {
+     "iopub.execute_input": "2026-03-23T16:01:44.082545Z",
+     "iopub.status.busy": "2026-03-23T16:01:44.082425Z",
+     "iopub.status.idle": "2026-03-23T16:01:44.085110Z",
+     "shell.execute_reply": "2026-03-23T16:01:44.084634Z"
     }
    },
    "outputs": [
@@ -1269,15 +1376,15 @@
        " 'function_name': 'lazily_create_long_term_memory',\n",
        " 'result': {'success': True,\n",
        "  'memory_type': 'semantic',\n",
-       "  'text_preview': \"User's name is Nitin and is planning a trip to Tokyo.\",\n",
-       "  'topics': ['travel'],\n",
-       "  'entities': ['Tokyo'],\n",
-       "  'summary': \"Successfully stored semantic memory: User's name is Nitin and is planning a trip to Tok...\"},\n",
+       "  'text_preview': 'User is planning a trip to Tokyo and is looking for vegetarian restaurants.',\n",
+       "  'topics': ['travel', 'preferences'],\n",
+       "  'entities': ['Tokyo', 'vegetarian', 'restaurants'],\n",
+       "  'summary': 'Successfully stored semantic memory: User is planning a trip to Tokyo and is looking fo...'},\n",
        " 'error': None,\n",
-       " 'formatted_response': \"Successfully stored semantic memory: User's name is Nitin and is planning a trip to Tok...\"}"
+       " 'formatted_response': 'Successfully stored semantic memory: User is planning a trip to Tokyo and is looking fo...'}"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1288,11 +1395,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 18,
    "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-02-05T02:03:10.575444Z",
-     "start_time": "2026-02-05T02:03:07.237353Z"
+    "execution": {
+     "iopub.execute_input": "2026-03-23T16:01:44.086597Z",
+     "iopub.status.busy": "2026-03-23T16:01:44.086476Z",
+     "iopub.status.idle": "2026-03-23T16:01:47.536195Z",
+     "shell.execute_reply": "2026-03-23T16:01:47.535364Z"
     }
    },
    "outputs": [
@@ -1301,15 +1410,15 @@
      "output_type": "stream",
      "text": [
       "Final LLM Response:\n",
-      "  Hi Nitin! That sounds exciting! For vegetarian restaurants in Tokyo, here are a few recommendations:\n",
+      "  Hi Nitin! That sounds exciting. Tokyo has a variety of great vegetarian restaurants. Here are a few popular options you might want to consider:\n",
       "\n",
-      "1. **Naritake** - This restaurant offers a variety of vegetarian ramen options.\n",
-      "2. **T's Tantan** - Located in Tokyo Station, this place is famous for its vegan ramen.\n",
-      "3. **Ain Soph. Journey** - A completely vegan restaurant with a menu full of delicious dishes.\n",
-      "4. **Kushitei** - A great spot for vegetarian skewers and side dishes.\n",
-      "5. **Sushi Saito** - Offers a vegetarian sushi menu.\n",
+      "1. **T's TanTan** - A well-known spot for vegan ramen and other Japanese dishes.\n",
+      "2. **Saido** - Offers a creative take on traditional Japanese cuisine, all vegetarian and vegan.\n",
+      "3. **Ain Soph. Journey** - A chic restaurant serving a range of vegan dishes, from burgers to desserts.\n",
+      "4. **Naritaya** - Famous for its vegan ramen and has a cozy atmosphere.\n",
+      "5. **The Farm Café** - A plant-based café that focuses on fresh ingredients and offers a relaxing environment.\n",
       "\n",
-      "Let me know if you need more information or specific recommendations!\n"
+      "Would you like more information on any of these or suggestions for a specific area in Tokyo?\n"
      ]
     }
    ],
@@ -1338,11 +1447,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 19,
    "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-02-05T02:03:23.069135Z",
-     "start_time": "2026-02-05T02:03:23.045258Z"
+    "execution": {
+     "iopub.execute_input": "2026-03-23T16:01:47.537862Z",
+     "iopub.status.busy": "2026-03-23T16:01:47.537712Z",
+     "iopub.status.idle": "2026-03-23T16:01:47.540729Z",
+     "shell.execute_reply": "2026-03-23T16:01:47.540254Z"
     }
    },
    "outputs": [
@@ -1350,21 +1461,21 @@
      "data": {
       "text/plain": [
        "[{'role': 'system',\n",
-       "  'content': \"You are a helpful assistant with persistent memory capabilities.\\n\\nWhen to remember (use create_long_term_memories tool):\\n- User preferences (food, communication style, etc.)\\n- Important personal information\\n- Project details and context\\n\\nWhen to search memory (use search_long_term_memory tool):\\n- User asks about previous conversations\\n- Context would help provide better responses\\n- User references something from the past\\n\\nAlways be transparent about what you're remembering.\"},\n",
+       "  'content': \"You are a helpful assistant with persistent memory capabilities.\\n\\nWhen to remember (use eagerly_create_long_term_memory tool):\\n- User preferences (food, communication style, etc.)\\n- Important personal information\\n- Project details and context\\n\\nWhen to search memory (use search_memory tool):\\n- User asks about previous conversations\\n- Context would help provide better responses\\n- User references something from the past\\n\\nAlways be transparent about what you're remembering.\"},\n",
        " {'role': 'user',\n",
        "  'content': \"Hi! I'm Nitin. I'm planning a trip to Tokyo and want to find good vegetarian restaurants.\"},\n",
        " {'role': 'assistant',\n",
        "  'content': None,\n",
-       "  'tool_calls': [{'id': 'call_Ux7XEoqyJxtOl68MPlE9ARjZ',\n",
+       "  'tool_calls': [{'id': 'call_CyqQuAbMVivDq6uHObE10XMK',\n",
        "    'type': 'function',\n",
        "    'function': {'name': 'lazily_create_long_term_memory',\n",
-       "     'arguments': '{\"text\":\"User\\'s name is Nitin and is planning a trip to Tokyo.\",\"memory_type\":\"semantic\",\"topics\":[\"travel\"],\"entities\":[\"Tokyo\"]}'}}]},\n",
-       " {'tool_call_id': 'call_Ux7XEoqyJxtOl68MPlE9ARjZ',\n",
+       "     'arguments': '{\"text\":\"User is planning a trip to Tokyo and is looking for vegetarian restaurants.\",\"memory_type\":\"semantic\",\"topics\":[\"travel\",\"preferences\"],\"entities\":[\"Tokyo\",\"vegetarian\",\"restaurants\"]}'}}]},\n",
+       " {'tool_call_id': 'call_CyqQuAbMVivDq6uHObE10XMK',\n",
        "  'role': 'tool',\n",
-       "  'content': '\"Successfully stored semantic memory: User\\'s name is Nitin and is planning a trip to Tok...\"'}]"
+       "  'content': '\"Successfully stored semantic memory: User is planning a trip to Tokyo and is looking fo...\"'}]"
       ]
      },
-     "execution_count": 38,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1451,11 +1562,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 20,
    "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-02-05T02:09:30.490211Z",
-     "start_time": "2026-02-05T02:09:30.468778Z"
+    "execution": {
+     "iopub.execute_input": "2026-03-23T16:01:47.543192Z",
+     "iopub.status.busy": "2026-03-23T16:01:47.543066Z",
+     "iopub.status.idle": "2026-03-23T16:01:47.556476Z",
+     "shell.execute_reply": "2026-03-23T16:01:47.555869Z"
     }
    },
    "outputs": [
@@ -1481,6 +1594,7 @@
     "created, working_memory = await client.get_or_create_working_memory(\n",
     "    session_id=SESSION_ID_AUTO,\n",
     "    namespace=NAMESPACE,\n",
+    "    user_id=USER_ID_AUTO,  # Include user_id for consistent session key\n",
     "    # Configure automatic extraction\n",
     "    long_term_memory_strategy=MemoryStrategyConfig(\n",
     "        strategy=\"discrete\"  # Extract individual facts (default)\n",
@@ -1494,21 +1608,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 21,
    "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-02-05T02:10:10.817694Z",
-     "start_time": "2026-02-05T02:10:10.800402Z"
+    "execution": {
+     "iopub.execute_input": "2026-03-23T16:01:47.558553Z",
+     "iopub.status.busy": "2026-03-23T16:01:47.558415Z",
+     "iopub.status.idle": "2026-03-23T16:01:47.566371Z",
+     "shell.execute_reply": "2026-03-23T16:01:47.565828Z"
     }
    },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "WorkingMemoryResponse(messages=[MemoryMessage(role='user', content=\"I'm Nitin. I'm planning a hiking trip to Japan and need vegetarian food options.\", id='01KGQ77RMQ6Z8EA9CRAY8FPVNP', created_at=datetime.datetime(2026, 2, 5, 15, 37, 52, 535148, tzinfo=TzInfo(0)), persisted_at=None, discrete_memory_extracted='f'), MemoryMessage(role='assistant', content='Great choice! Japan has amazing hiking trails and excellent vegetarian cuisine.', id='01KGQ77RMQ6Z8EA9CRAY8FPVNQ', created_at=datetime.datetime(2026, 2, 5, 15, 37, 52, 535182, tzinfo=TzInfo(0)), persisted_at=None, discrete_memory_extracted='f'), MemoryMessage(role='user', content='I prefer nice hotels with good amenities, not too fancy but comfortable. All depends on the budget.', id='01KGQ77RMQ6Z8EA9CRAY8FPVNR', created_at=datetime.datetime(2026, 2, 5, 15, 37, 52, 535201, tzinfo=TzInfo(0)), persisted_at=None, discrete_memory_extracted='f'), MemoryMessage(role='assistant', content=\"Noted! I'll remember your preference for comfortable mid-tier accommodations.\", id='01KGQ77RMQ6Z8EA9CRAY8FPVNS', created_at=datetime.datetime(2026, 2, 5, 15, 37, 52, 535219, tzinfo=TzInfo(0)), persisted_at=None, discrete_memory_extracted='f')], memories=[], data=None, context=None, user_id='nitin', tokens=0, session_id='nitin-auto-session', namespace='travel_agent', long_term_memory_strategy=MemoryStrategyConfig(strategy='discrete', config={}), ttl_seconds=None, last_accessed=datetime.datetime(2026, 2, 5, 15, 37, 52, 535296, tzinfo=TzInfo(0)), context_percentage_total_used=None, context_percentage_until_summarization=None, new_session=None, unsaved=None)"
+       "WorkingMemoryResponse(messages=[MemoryMessage(role='user', content=\"I'm Nitin. I'm planning a hiking trip to Japan and need vegetarian food options.\", id='01KMDPWM17816CXXJ0RXKYXFR3', created_at=datetime.datetime(2026, 3, 23, 16, 1, 47, 559506, tzinfo=TzInfo(0)), persisted_at=None, discrete_memory_extracted='f'), MemoryMessage(role='assistant', content='Great choice! Japan has amazing hiking trails and excellent vegetarian cuisine.', id='01KMDPWM17816CXXJ0RXKYXFR4', created_at=datetime.datetime(2026, 3, 23, 16, 1, 47, 559547, tzinfo=TzInfo(0)), persisted_at=None, discrete_memory_extracted='f'), MemoryMessage(role='user', content='I prefer nice hotels with good amenities, not too fancy but comfortable. All depends on the budget.', id='01KMDPWM17816CXXJ0RXKYXFR5', created_at=datetime.datetime(2026, 3, 23, 16, 1, 47, 559561, tzinfo=TzInfo(0)), persisted_at=None, discrete_memory_extracted='f'), MemoryMessage(role='assistant', content=\"Noted! I'll remember your preference for comfortable mid-tier accommodations.\", id='01KMDPWM17816CXXJ0RXKYXFR6', created_at=datetime.datetime(2026, 3, 23, 16, 1, 47, 559571, tzinfo=TzInfo(0)), persisted_at=None, discrete_memory_extracted='f')], memories=[], data=None, context=None, user_id='nitin', tokens=0, session_id='nitin-auto-session', namespace='travel_agent', long_term_memory_strategy=MemoryStrategyConfig(strategy='discrete', config={}), ttl_seconds=None, last_accessed=datetime.datetime(2026, 3, 23, 16, 1, 47, 559614, tzinfo=TzInfo(0)), context_percentage_total_used=None, context_percentage_until_summarization=None, new_session=None, unsaved=None)"
       ]
      },
-     "execution_count": 24,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1516,10 +1632,10 @@
    "source": [
     "# Step 2: Just store the conversation - extraction happens automatically!\n",
     "conversation = [\n",
-    "    MemoryMessage(role=\"user\", content=\"I'm Nitin. I'm planning a hiking trip to Japan and need vegetarian food options.\"),\n",
-    "    MemoryMessage(role=\"assistant\", content=\"Great choice! Japan has amazing hiking trails and excellent vegetarian cuisine.\"),\n",
-    "    MemoryMessage(role=\"user\", content=\"I prefer nice hotels with good amenities, not too fancy but comfortable. All depends on the budget.\"),\n",
-    "    MemoryMessage(role=\"assistant\", content=\"Noted! I'll remember your preference for comfortable mid-tier accommodations.\")\n",
+    "    MemoryMessage(role=\"user\", content=\"I'm Nitin. I'm planning a hiking trip to Japan and need vegetarian food options.\", created_at=datetime.now(timezone.utc)),\n",
+    "    MemoryMessage(role=\"assistant\", content=\"Great choice! Japan has amazing hiking trails and excellent vegetarian cuisine.\", created_at=datetime.now(timezone.utc)),\n",
+    "    MemoryMessage(role=\"user\", content=\"I prefer nice hotels with good amenities, not too fancy but comfortable. All depends on the budget.\", created_at=datetime.now(timezone.utc)),\n",
+    "    MemoryMessage(role=\"assistant\", content=\"Noted! I'll remember your preference for comfortable mid-tier accommodations.\", created_at=datetime.now(timezone.utc))\n",
     "]\n",
     "\n",
     "working_memory_update = WorkingMemory(\n",
@@ -1536,12 +1652,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-02-05T02:10:17.012880Z",
-     "start_time": "2026-02-05T02:10:16.988805Z"
-    }
-   },
+   "metadata": {},
    "source": [
     "Conversation stored in working memory\n",
     "\n",
@@ -1555,11 +1666,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 22,
    "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-02-05T02:11:30.321788Z",
-     "start_time": "2026-02-05T02:11:30.296327Z"
+    "execution": {
+     "iopub.execute_input": "2026-03-23T16:01:47.567965Z",
+     "iopub.status.busy": "2026-03-23T16:01:47.567859Z",
+     "iopub.status.idle": "2026-03-23T16:01:47.576583Z",
+     "shell.execute_reply": "2026-03-23T16:01:47.576146Z"
     }
    },
    "outputs": [
@@ -1606,21 +1719,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 23,
    "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-02-05T02:11:45.320841Z",
-     "start_time": "2026-02-05T02:11:45.300909Z"
+    "execution": {
+     "iopub.execute_input": "2026-03-23T16:01:47.578371Z",
+     "iopub.status.busy": "2026-03-23T16:01:47.578225Z",
+     "iopub.status.idle": "2026-03-23T16:01:47.580922Z",
+     "shell.execute_reply": "2026-03-23T16:01:47.580518Z"
     }
    },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "WorkingMemoryResponse(messages=[], memories=[], data={}, context=None, user_id=None, tokens=0, session_id='custom-extraction-demo', namespace='travel_agent', long_term_memory_strategy=MemoryStrategyConfig(strategy='custom', config={'custom_prompt': 'Extract technical decisions and preferences from this conversation.\\n\\nFocus on:\\n- Programming languages and frameworks mentioned\\n- Tool preferences\\n- Work schedule preferences\\n- Communication preferences\\n\\nFormat each as a clear, standalone statement.\\nCurrent datetime: {current_datetime}\\nConversation: {message}'}), ttl_seconds=None, last_accessed=datetime.datetime(2026, 2, 5, 15, 38, 56, 239184, tzinfo=TzInfo(0)), context_percentage_total_used=None, context_percentage_until_summarization=None, new_session=None, unsaved=None)"
+       "WorkingMemoryResponse(messages=[], memories=[], data={}, context=None, user_id=None, tokens=0, session_id='custom-extraction-demo', namespace='travel_agent', long_term_memory_strategy=MemoryStrategyConfig(strategy='custom', config={'custom_prompt': 'Extract technical decisions and preferences from this conversation.\\n\\nFocus on:\\n- Programming languages and frameworks mentioned\\n- Tool preferences\\n- Work schedule preferences\\n- Communication preferences\\n\\nFormat each as a clear, standalone statement.\\nCurrent datetime: {current_datetime}\\nConversation: {message}'}), ttl_seconds=None, last_accessed=datetime.datetime(2026, 3, 23, 16, 1, 47, 571905, tzinfo=TzInfo(0)), context_percentage_total_used=None, context_percentage_until_summarization=None, new_session=None, unsaved=None)"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2074,9 +2189,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 24,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-23T16:01:47.582537Z",
+     "iopub.status.busy": "2026-03-23T16:01:47.582440Z",
+     "iopub.status.idle": "2026-03-23T16:01:47.590224Z",
+     "shell.execute_reply": "2026-03-23T16:01:47.589814Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found 5 session(s) in 'travel_agent' namespace:\n",
+      "  - nitin-travel-session\n",
+      "  - nitin-travel-session-2\n",
+      "  - nitin-llm-session\n",
+      "  - nitin-auto-session\n",
+      "  - custom-extraction-demo\n"
+     ]
+    }
+   ],
    "source": [
     "# Working Memory Operations\n",
     "\n",
@@ -2089,17 +2224,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": 25,
    "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-02-05T02:17:18.313090Z",
-     "start_time": "2026-02-05T02:17:18.284498Z"
-    },
     "execution": {
-     "iopub.execute_input": "2026-02-05T01:31:46.199478Z",
-     "iopub.status.busy": "2026-02-05T01:31:46.199395Z",
-     "iopub.status.idle": "2026-02-05T01:31:46.206616Z",
-     "shell.execute_reply": "2026-02-05T01:31:46.206338Z"
+     "iopub.execute_input": "2026-03-23T16:01:47.591737Z",
+     "iopub.status.busy": "2026-03-23T16:01:47.591638Z",
+     "iopub.status.idle": "2026-03-23T16:01:47.601574Z",
+     "shell.execute_reply": "2026-03-23T16:01:47.601136Z"
     }
    },
    "outputs": [
@@ -2131,17 +2262,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": 26,
    "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-02-05T02:17:23.748130Z",
-     "start_time": "2026-02-05T02:17:23.729940Z"
-    },
     "execution": {
-     "iopub.execute_input": "2026-02-05T01:31:46.207927Z",
-     "iopub.status.busy": "2026-02-05T01:31:46.207850Z",
-     "iopub.status.idle": "2026-02-05T01:31:46.215581Z",
-     "shell.execute_reply": "2026-02-05T01:31:46.215256Z"
+     "iopub.execute_input": "2026-03-23T16:01:47.602941Z",
+     "iopub.status.busy": "2026-03-23T16:01:47.602853Z",
+     "iopub.status.idle": "2026-03-23T16:01:47.614088Z",
+     "shell.execute_reply": "2026-03-23T16:01:47.613756Z"
     }
    },
    "outputs": [
@@ -2179,17 +2306,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
+   "execution_count": 27,
    "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-02-05T02:17:34.304469Z",
-     "start_time": "2026-02-05T02:17:32.036207Z"
-    },
     "execution": {
-     "iopub.execute_input": "2026-02-05T01:31:46.217044Z",
-     "iopub.status.busy": "2026-02-05T01:31:46.216943Z",
-     "iopub.status.idle": "2026-02-05T01:31:48.626006Z",
-     "shell.execute_reply": "2026-02-05T01:31:48.625319Z"
+     "iopub.execute_input": "2026-03-23T16:01:47.615494Z",
+     "iopub.status.busy": "2026-03-23T16:01:47.615416Z",
+     "iopub.status.idle": "2026-03-23T16:01:50.028915Z",
+     "shell.execute_reply": "2026-03-23T16:01:50.028130Z"
     }
    },
    "outputs": [
@@ -2199,20 +2322,20 @@
      "text": [
       "Found 5 memories for user 'nitin':\n",
       "\n",
-      "  [63%] User's name is Nitin and he is planning a trip to Tokyo.\n",
-      "       Topics: ['travel']\n",
-      "\n",
-      "  [45%] User prefers comfortable mid-tier accommodations with good amenities while traveling.\n",
-      "       Topics: ['travel', 'accommodations', 'preferences']\n",
-      "\n",
       "  [41%] Prefers hotels with good amenities\n",
       "       Topics: ['travel', 'preferences']\n",
       "\n",
       "  [38%] Comfort travel - middle tier (not luxury, not budget)\n",
       "       Topics: ['travel', 'preferences']\n",
       "\n",
-      "  [37%] User enjoys hiking and vegetarian food.\n",
-      "       Topics: ['travel', 'food', 'hiking']\n"
+      "  [36%] Enjoys technology, sports, outdoords, and innovation hubs\n",
+      "       Topics: ['travel', 'preferences']\n",
+      "\n",
+      "  [33%] User is planning a trip to Tokyo and is looking for vegetarian restaurants.\n",
+      "       Topics: ['travel', 'preferences']\n",
+      "\n",
+      "  [29%] Extra leg room on flights (premium economy or exit row and budget allows, anything goes)\n",
+      "       Topics: ['travel', 'preferences']\n"
      ]
     }
    ],
@@ -2237,17 +2360,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 62,
+   "execution_count": 28,
    "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-02-05T02:17:34.613078Z",
-     "start_time": "2026-02-05T02:17:34.313021Z"
-    },
     "execution": {
-     "iopub.execute_input": "2026-02-05T01:31:48.627719Z",
-     "iopub.status.busy": "2026-02-05T01:31:48.627597Z",
-     "iopub.status.idle": "2026-02-05T01:31:48.909874Z",
-     "shell.execute_reply": "2026-02-05T01:31:48.909320Z"
+     "iopub.execute_input": "2026-03-23T16:01:50.031041Z",
+     "iopub.status.busy": "2026-03-23T16:01:50.030866Z",
+     "iopub.status.idle": "2026-03-23T16:01:50.271739Z",
+     "shell.execute_reply": "2026-03-23T16:01:50.270999Z"
     }
    },
    "outputs": [
@@ -2255,10 +2374,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Filtered search found 10 memories\n",
-      "  - Comfort travel - middle tier (not luxury, not budget)...\n",
-      "  - User prefers comfortable mid-tier accommodations with good a...\n",
-      "  - Extra leg room on flights (premium economy or exit row and b...\n"
+      "Filtered search found 6 memories\n",
+      "  - Comfort travel - middle tier (not luxury, not budget)\n",
+      "  - Extra leg room on flights (premium economy or exit row and budget allows, anything goes)\n",
+      "  - Prefers hotels with good amenities\n",
+      "  - Enjoys technology, sports, outdoords, and innovation hubs\n",
+      "  - User is planning a trip to Tokyo and is looking for vegetarian restaurants.\n",
+      "  - Vegetarian diet - needs vegetarian restaurant options\n"
      ]
     }
    ],
@@ -2277,6 +2399,140 @@
     "print(f\"Filtered search found {results.total} memories\")\n",
     "for mem in results.memories:\n",
     "    print(f\"  - {mem.text}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Recency Boost (Default: Enabled)\n",
+    "\n",
+    "Search results are **automatically re-ranked** using recency boost, which combines semantic similarity with time-based relevance. This ensures recent and frequently accessed memories appear higher in results.\n",
+    "\n",
+    "#### How It Works\n",
+    "\n",
+    "```\n",
+    "final_score = (semantic_weight × similarity) + (recency_weight × recency_score)\n",
+    "\n",
+    "where:\n",
+    "recency_score = (freshness_weight × freshness) + (novelty_weight × novelty)\n",
+    "```\n",
+    "\n",
+    "| Component | Description | Default Weight |\n",
+    "|-----------|-------------|----------------|\n",
+    "| **Semantic similarity** | Vector cosine similarity | 0.8 (80%) |\n",
+    "| **Recency score** | Time-based relevance | 0.2 (20%) |\n",
+    "| **Freshness** | When the memory was created | 0.6 |\n",
+    "| **Novelty** | When the memory was last accessed | 0.4 |\n",
+    "\n",
+    "#### Default Behavior\n",
+    "\n",
+    "With default settings, a memory from yesterday with 70% semantic similarity may rank higher than a memory from 6 months ago with 85% similarity."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-23T16:01:50.273682Z",
+     "iopub.status.busy": "2026-03-23T16:01:50.273523Z",
+     "iopub.status.idle": "2026-03-23T16:01:50.590191Z",
+     "shell.execute_reply": "2026-03-23T16:01:50.589603Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found 5 memories with recency boost:\n",
+      "  [34%] Comfort travel - middle tier (not luxury, not budget)\n",
+      "  [33%] User is planning a trip to Tokyo and is looking for vegetarian restaurants.\n",
+      "  [30%] Extra leg room on flights (premium economy or exit row and budget allows, anything goes)\n",
+      "  [27%] Prefers hotels with good amenities\n",
+      "  [22%] Enjoys technology, sports, outdoords, and innovation hubs\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Search with custom recency configuration\n",
+    "from agent_memory_client.models import RecencyConfig\n",
+    "\n",
+    "# Increase recency weight for time-sensitive queries\n",
+    "results_recency = await client.search_long_term_memory(\n",
+    "    text=\"recent trip plans\",\n",
+    "    namespace={\"eq\": \"travel_agent\"},\n",
+    "    user_id={\"eq\": \"nitin\"},\n",
+    "    recency=RecencyConfig(\n",
+    "        recency_boost=True,\n",
+    "        semantic_weight=0.6,  # Lower semantic weight\n",
+    "        recency_weight=0.4,   # Higher recency weight\n",
+    "        half_life_last_access_days=3.0,  # Faster decay\n",
+    "        half_life_created_days=14.0\n",
+    "    ),\n",
+    "    limit=5\n",
+    ")\n",
+    "\n",
+    "print(f\"Found {results_recency.total} memories with recency boost:\")\n",
+    "for mem in results_recency.memories:\n",
+    "    relevance = (1 - mem.dist) * 100\n",
+    "    print(f\"  [{relevance:.0f}%] {mem.text}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-23T16:01:50.592294Z",
+     "iopub.status.busy": "2026-03-23T16:01:50.592150Z",
+     "iopub.status.idle": "2026-03-23T16:01:50.994867Z",
+     "shell.execute_reply": "2026-03-23T16:01:50.994283Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Pure semantic search found 5 memories:\n",
+      "  [48%] Comfort travel - middle tier (not luxury, not budget)\n",
+      "  [41%] Extra leg room on flights (premium economy or exit row and budget allows, anything goes)\n",
+      "  [37%] Prefers hotels with good amenities\n",
+      "  [31%] Enjoys technology, sports, outdoords, and innovation hubs\n",
+      "  [30%] User is planning a trip to Tokyo and is looking for vegetarian restaurants.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Disable recency boost for pure semantic search (e.g., historical research)\n",
+    "results_pure_semantic = await client.search_long_term_memory(\n",
+    "    text=\"travel preferences\",\n",
+    "    namespace={\"eq\": \"travel_agent\"},\n",
+    "    user_id={\"eq\": \"nitin\"},\n",
+    "    recency=RecencyConfig(recency_boost=False),  # Pure vector similarity\n",
+    "    limit=5\n",
+    ")\n",
+    "\n",
+    "print(f\"Pure semantic search found {results_pure_semantic.total} memories:\")\n",
+    "for mem in results_pure_semantic.memories:\n",
+    "    relevance = (1 - mem.dist) * 100\n",
+    "    print(f\"  [{relevance:.0f}%] {mem.text}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### When to Adjust Recency\n",
+    "\n",
+    "| Use Case | Configuration |\n",
+    "|----------|---------------|\n",
+    "| **Real-time apps** (news, support) | Higher recency_weight (0.4), shorter half-lives |\n",
+    "| **Knowledge bases** | Lower recency_weight (0.1), longer half-lives |\n",
+    "| **Historical research** | Disable: `recency_boost=False` |\n",
+    "| **Default (most apps)** | Keep defaults (0.8 semantic, 0.2 recency) |"
    ]
   },
   {
@@ -2305,17 +2561,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": 31,
    "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-02-05T02:17:49.503546Z",
-     "start_time": "2026-02-05T02:17:49.481290Z"
-    },
     "execution": {
-     "iopub.execute_input": "2026-02-05T01:31:48.911605Z",
-     "iopub.status.busy": "2026-02-05T01:31:48.911476Z",
-     "iopub.status.idle": "2026-02-05T01:31:48.915597Z",
-     "shell.execute_reply": "2026-02-05T01:31:48.915080Z"
+     "iopub.execute_input": "2026-03-23T16:01:50.996612Z",
+     "iopub.status.busy": "2026-03-23T16:01:50.996480Z",
+     "iopub.status.idle": "2026-03-23T16:01:51.000650Z",
+     "shell.execute_reply": "2026-03-23T16:01:51.000089Z"
     }
    },
    "outputs": [
@@ -2324,7 +2576,7 @@
      "output_type": "stream",
      "text": [
       "Created episodic memory: ok\n",
-      "Event date: 2026-01-29 02:17:49.484219+00:00\n"
+      "Event date: 2026-03-16 16:01:50.997363+00:00\n"
      ]
     }
    ],
@@ -2363,9 +2615,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 32,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-23T16:01:51.002041Z",
+     "iopub.status.busy": "2026-03-23T16:01:51.001936Z",
+     "iopub.status.idle": "2026-03-23T16:01:51.004116Z",
+     "shell.execute_reply": "2026-03-23T16:01:51.003656Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Sample conversation:\n",
+      "\n",
+      "User: I'm looking to rent a car for my trip to Colorado next month.\n",
+      "Agent: I'd be happy to help! What type of vehicle are you looking for?\n",
+      "User: I definitely want an SUV - something like a Toyota 4Runner or Jeep Grand Cherokee.\n",
+      "      I prefer darker colors like charcoal gray or navy blue, nothing too flashy.\n",
+      "      Must have 4WD for the mountain roads, and I'd love heated seats since it'll be cold.\n",
+      "      My budget is around $75-100 per day, and I'll need it for 5 days starting March 15th.\n",
+      "Agent: Great choices! Any other preferences?\n",
+      "User: Yes, I need a roof rack for my ski equipment, and Apple CarPlay is a must.\n",
+      "      Also, I prefer to pick up from Denver airport rather than downtown.\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "# Sample conversation with detailed vehicle preferences\n",
     "vehicle_conversation = \"\"\"\n",
@@ -2395,9 +2673,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 33,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-23T16:01:51.005572Z",
+     "iopub.status.busy": "2026-03-23T16:01:51.005482Z",
+     "iopub.status.idle": "2026-03-23T16:01:51.008427Z",
+     "shell.execute_reply": "2026-03-23T16:01:51.007907Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DISCRETE Strategy Results:\n",
+      "==================================================\n",
+      "1. [SEMANTIC] User prefers SUVs for car rentals\n",
+      "2. [SEMANTIC] User prefers darker vehicle colors\n",
+      "3. [EPISODIC] User planning trip to Colorado in March 2026\n",
+      "4. [SEMANTIC] User's car rental budget is $75-100 per day\n",
+      "\n",
+      "Total memories extracted: 4\n"
+     ]
+    }
+   ],
    "source": [
     "# What the DISCRETE strategy would extract (simulated output)\n",
     "# In production, this happens automatically via background extraction\n",
@@ -2447,9 +2747,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 34,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-23T16:01:51.009898Z",
+     "iopub.status.busy": "2026-03-23T16:01:51.009811Z",
+     "iopub.status.idle": "2026-03-23T16:01:51.011929Z",
+     "shell.execute_reply": "2026-03-23T16:01:51.011476Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Custom prompt configured for granular vehicle preference extraction\n"
+     ]
+    }
+   ],
    "source": [
     "# Custom prompt for vehicle rental extraction\n",
     "vehicle_rental_custom_prompt = '''\n",
@@ -2484,9 +2799,36 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 35,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-23T16:01:51.013287Z",
+     "iopub.status.busy": "2026-03-23T16:01:51.013189Z",
+     "iopub.status.idle": "2026-03-23T16:01:51.016661Z",
+     "shell.execute_reply": "2026-03-23T16:01:51.016234Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CUSTOM Strategy Results:\n",
+      "==================================================\n",
+      "1. [SEMANTIC] User prefers Toyota 4Runner or Jeep Grand Cherokee for rentals\n",
+      "2. [SEMANTIC] User prefers charcoal gray or navy blue vehicle colors\n",
+      "3. [SEMANTIC] User requires 4WD capability for mountain driving\n",
+      "4. [SEMANTIC] User requires heated seats in rental vehicles\n",
+      "5. [SEMANTIC] User's rental budget is $75-100 per day for 5 days ($375-500 total)\n",
+      "6. [EPISODIC] User needs rental starting March 15, 2026 for Colorado trip\n",
+      "7. [SEMANTIC] User requires roof rack for ski equipment\n",
+      "8. [SEMANTIC] User requires Apple CarPlay in rental vehicle\n",
+      "9. [SEMANTIC] User prefers Denver airport pickup over downtown locations\n",
+      "\n",
+      "Total memories extracted: 9\n"
+     ]
+    }
+   ],
    "source": [
     "# What the CUSTOM strategy would extract (simulated output)\n",
     "custom_extraction_results = [\n",
@@ -2584,9 +2926,9 @@
     "_, wm = await client.get_or_create_working_memory(\n",
     "    session_id=\"vehicle-rental-session\",\n",
     "    namespace=\"travel_agent\",\n",
-    "    memory_strategy=MemoryStrategyConfig(\n",
+    "    long_term_memory_strategy=MemoryStrategyConfig(\n",
     "        strategy=\"custom\",\n",
-    "        custom_prompt=vehicle_rental_custom_prompt\n",
+    "        config={\"custom_prompt\": vehicle_rental_custom_prompt}\n",
     "    )\n",
     ")\n",
     "```"
@@ -2643,17 +2985,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 64,
+   "execution_count": 36,
    "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-02-05T02:18:27.336935Z",
-     "start_time": "2026-02-05T02:18:27.315040Z"
-    },
     "execution": {
-     "iopub.execute_input": "2026-02-05T01:31:48.916883Z",
-     "iopub.status.busy": "2026-02-05T01:31:48.916789Z",
-     "iopub.status.idle": "2026-02-05T01:31:48.919219Z",
-     "shell.execute_reply": "2026-02-05T01:31:48.918713Z"
+     "iopub.execute_input": "2026-03-23T16:01:51.017853Z",
+     "iopub.status.busy": "2026-03-23T16:01:51.017781Z",
+     "iopub.status.idle": "2026-03-23T16:01:51.019916Z",
+     "shell.execute_reply": "2026-03-23T16:01:51.019528Z"
     }
    },
    "outputs": [


### PR DESCRIPTION
- Change memory_prompt query to 'What are my travel preferences?' for better semantic match with stored memories
- Remove restrictive distance_threshold (0.7) to use server defaults for broader recall
- Fix memory count logic to use '(ID:' pattern instead of bullet counting
- Increase indexing wait time from 2s to 3s for reliability



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation/demo-only notebook updates (query params, sample outputs, and additional example cells) with no production code changes; risk is limited to potentially confusing users if outputs/tool names drift from the API.
> 
> **Overview**
> Improves the `agent_memory_server_interactive_guide.ipynb` walkthrough to make the `memory_prompt()` demo return the full set of seeded preferences by adjusting the sample query, increasing the indexing wait, and relying on server-default long-term search thresholds.
> 
> Fixes the notebook’s long-term memory count display by counting `"(ID:"` occurrences instead of bullet formatting, and updates working-memory examples to include explicit `created_at` timestamps to avoid warnings.
> 
> Adds/refreshes examples around session listing and **recency boost** search re-ranking (including how to disable it for pure semantic search), and updates LLM-tooling instructions to reference the current tool names (e.g., `search_memory`, `eagerly_create_long_term_memory`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3bed90dd61a4f5121f097615ecd0ecff1adbc52b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->