### PR TITLE
fix: pin litellm to GitHub commit to bypass PyPI quarantine

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "python-ulid>=3.0.0",
     "bcrypt>=4.0.0",
     "cachetools>=6.2.2,<7.0.0",
-    "litellm @ git+https://github.com/BerriAI/litellm.git@57e07bddd34185934893de3ad74583ba119ed67d",
+    "litellm @ https://github.com/BerriAI/litellm/archive/57e07bddd34185934893de3ad74583ba119ed67d.zip",
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -127,7 +127,7 @@ requires-dist = [
     { name = "cryptography", specifier = ">=3.4.8" },
     { name = "fastapi", specifier = ">=0.115.11" },
     { name = "httpx", specifier = ">=0.25.0" },
-    { name = "litellm", git = "https://github.com/BerriAI/litellm.git?rev=57e07bddd34185934893de3ad74583ba119ed67d" },
+    { name = "litellm", url = "https://github.com/BerriAI/litellm/archive/57e07bddd34185934893de3ad74583ba119ed67d.zip" },
     { name = "mcp", specifier = ">=1.6.0" },
     { name = "numpy", specifier = ">=2.1.0" },
     { name = "openai", specifier = ">=1.3.7" },
@@ -1373,7 +1373,7 @@ wheels = [
 [[package]]
 name = "litellm"
 version = "1.80.11"
-source = { git = "https://github.com/BerriAI/litellm.git?rev=57e07bddd34185934893de3ad74583ba119ed67d#57e07bddd34185934893de3ad74583ba119ed67d" }
+source = { url = "https://github.com/BerriAI/litellm/archive/57e07bddd34185934893de3ad74583ba119ed67d.zip" }
 dependencies = [
     { name = "aiohttp" },
     { name = "click" },
@@ -1389,6 +1389,60 @@ dependencies = [
     { name = "tiktoken" },
     { name = "tokenizers" },
 ]
+sdist = { hash = "sha256:527917cef8a89429b171f6a8de4fcaed40ebec2cff37fe7caaa82c095e38b245" }
+
+[package.metadata]
+requires-dist = [
+    { name = "aiohttp", specifier = ">=3.10" },
+    { name = "apscheduler", marker = "extra == 'proxy'", specifier = ">=3.10.4,<4.0.0" },
+    { name = "azure-identity", marker = "(python_full_version >= '3.9' and extra == 'extra-proxy') or (python_full_version >= '3.9' and extra == 'proxy')", specifier = ">=1.15.0,<2.0.0" },
+    { name = "azure-keyvault-secrets", marker = "extra == 'extra-proxy'", specifier = ">=4.8.0,<5.0.0" },
+    { name = "azure-storage-blob", marker = "extra == 'proxy'", specifier = ">=12.25.1,<13.0.0" },
+    { name = "backoff", marker = "extra == 'proxy'" },
+    { name = "boto3", marker = "extra == 'proxy'", specifier = "==1.36.0" },
+    { name = "click" },
+    { name = "cryptography", marker = "extra == 'proxy'" },
+    { name = "diskcache", marker = "extra == 'caching'", specifier = ">=5.6.1,<6.0.0" },
+    { name = "fastapi", marker = "extra == 'proxy'", specifier = ">=0.120.1" },
+    { name = "fastapi-sso", marker = "extra == 'proxy'", specifier = ">=0.16.0,<0.17.0" },
+    { name = "fastuuid", specifier = ">=0.13.0" },
+    { name = "google-cloud-iam", marker = "extra == 'extra-proxy'", specifier = ">=2.19.1,<3.0.0" },
+    { name = "google-cloud-kms", marker = "extra == 'extra-proxy'", specifier = ">=2.21.3,<3.0.0" },
+    { name = "grpcio", marker = "python_full_version < '3.14'", specifier = ">=1.62.3,<1.68.0" },
+    { name = "grpcio", marker = "python_full_version >= '3.14'", specifier = ">=1.75.0" },
+    { name = "gunicorn", marker = "extra == 'proxy'", specifier = ">=23.0.0,<24.0.0" },
+    { name = "httpx", specifier = ">=0.23.0" },
+    { name = "importlib-metadata", specifier = ">=6.8.0" },
+    { name = "jinja2", specifier = ">=3.1.2,<4.0.0" },
+    { name = "jsonschema", specifier = ">=4.23.0,<5.0.0" },
+    { name = "litellm-enterprise", marker = "extra == 'proxy'", specifier = "==0.1.27" },
+    { name = "litellm-proxy-extras", marker = "extra == 'proxy'", specifier = "==0.4.16" },
+    { name = "mcp", marker = "python_full_version >= '3.10' and extra == 'proxy'", specifier = ">=1.21.2,<2.0.0" },
+    { name = "mlflow", marker = "python_full_version >= '3.10' and extra == 'mlflow'", specifier = ">3.1.4" },
+    { name = "numpydoc", marker = "extra == 'utils'" },
+    { name = "openai", specifier = ">=2.8.0" },
+    { name = "orjson", marker = "extra == 'proxy'", specifier = ">=3.9.7,<4.0.0" },
+    { name = "polars", marker = "python_full_version >= '3.10' and extra == 'proxy'", specifier = ">=1.31.0,<2.0.0" },
+    { name = "prisma", marker = "extra == 'extra-proxy'", specifier = "==0.11.0" },
+    { name = "pydantic", specifier = ">=2.5.0,<3.0.0" },
+    { name = "pyjwt", marker = "python_full_version >= '3.9' and extra == 'proxy'", specifier = ">=2.10.1,<3.0.0" },
+    { name = "pynacl", marker = "extra == 'proxy'", specifier = ">=1.5.0,<2.0.0" },
+    { name = "python-dotenv", specifier = ">=0.2.0" },
+    { name = "python-multipart", marker = "extra == 'proxy'", specifier = ">=0.0.18,<0.0.19" },
+    { name = "pyyaml", marker = "extra == 'proxy'", specifier = ">=6.0.1,<7.0.0" },
+    { name = "redisvl", marker = "python_full_version >= '3.9' and python_full_version < '3.14' and extra == 'extra-proxy'", specifier = ">=0.4.1,<0.5.0" },
+    { name = "resend", marker = "extra == 'extra-proxy'", specifier = ">=0.8.0" },
+    { name = "rich", marker = "extra == 'proxy'", specifier = "==13.7.1" },
+    { name = "rq", marker = "extra == 'proxy'" },
+    { name = "semantic-router", marker = "python_full_version >= '3.9' and python_full_version < '3.14' and extra == 'semantic-router'", specifier = ">=0.1.12" },
+    { name = "soundfile", marker = "extra == 'proxy'", specifier = ">=0.12.1,<0.13.0" },
+    { name = "tiktoken", specifier = ">=0.7.0" },
+    { name = "tokenizers" },
+    { name = "uvicorn", marker = "extra == 'proxy'", specifier = ">=0.31.1,<0.32.0" },
+    { name = "uvloop", marker = "sys_platform != 'win32' and extra == 'proxy'", specifier = ">=0.21.0,<0.22.0" },
+    { name = "websockets", marker = "extra == 'proxy'", specifier = ">=15.0.1,<16.0.0" },
+]
+provides-extras = ["caching", "extra-proxy", "mlflow", "proxy", "semantic-router", "utils"]
 
 [[package]]
 name = "lupa"


### PR DESCRIPTION
pin litellm to GitHub commit to bypass PyPI quarantine
litellm 1.82.7 and 1.82.8 on PyPI contain malware (supply chain attack). PyPI has quarantined the entire package, blocking all installs. Pin to commit 57e07bd (v1.80.11-stable) from GitHub as a workaround.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Switches `litellm` from a PyPI version range to a direct GitHub archive URL, which changes the supply chain/build reproducibility surface and could introduce differences from the previously resolved PyPI artifact.
> 
> **Overview**
> Pins **`litellm`** to a specific GitHub commit archive (`57e07bd...`) instead of installing from PyPI via `>=1.80.11`, updating both `pyproject.toml` and `uv.lock` to use the direct URL source.
> 
> The lockfile is regenerated to reflect the URL-based source and updated package metadata for `litellm` (and associated lock entries).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 59e339c2bd87ebee8ad5e52dea9cfffc1286b84b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->