### PR TITLE
Fix hsetex FXX enum usage

### DIFF
--- a/agent_memory_server/long_term_memory.py
+++ b/agent_memory_server/long_term_memory.py
@@ -10,6 +10,7 @@ from typing import Any
 from docket import Timeout
 from docket.dependencies import Perpetual
 from redis.asyncio import Redis
+from redis.commands.core import HashDataPersistOptions
 from ulid import ULID
 
 from agent_memory_server.config import settings
@@ -542,7 +543,7 @@ async def extract_memory_structure(
             "topics": encode_tag_values(merged_topics),
             "entities": encode_tag_values(merged_entities),
         },
-        data_persist_option="FXX",
+        data_persist_option=HashDataPersistOptions.FXX,
         keepttl=True,
     )
     if result == 0:

--- a/tests/test_long_term_memory.py
+++ b/tests/test_long_term_memory.py
@@ -3,6 +3,7 @@ from unittest import mock
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
+from redis.commands.core import HashDataPersistOptions
 
 from agent_memory_server.filters import Entities, Namespace, SessionId, Topics
 from agent_memory_server.long_term_memory import (
@@ -343,7 +344,7 @@ class TestLongTermMemory:
             mapping = call_kwargs[1]["mapping"]
             assert mapping["topics"] == "topic1,topic2"
             assert mapping["entities"] == "entity1,entity2"
-            assert call_kwargs[1]["data_persist_option"] == "FXX"
+            assert call_kwargs[1]["data_persist_option"] == HashDataPersistOptions.FXX
             assert call_kwargs[1]["keepttl"] is True
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- use `HashDataPersistOptions.FXX` when calling `redis.hsetex()` in `extract_memory_structure`
- update the regression test to assert the enum value expected by the redis client

## Testing
- `make test-api`
- `make pre-commit`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small compatibility fix that changes only the `redis.hsetex()` argument type and updates the corresponding unit test assertion, without altering memory extraction logic or data formats.
> 
> **Overview**
> Fixes the `extract_memory_structure` Redis write guard to pass `HashDataPersistOptions.FXX` (instead of the string `"FXX"`) to `redis.hsetex()`, matching the redis-py client’s expected API.
> 
> Updates the regression test to assert the enum value is used when calling `hsetex`, keeping the atomic “only update if fields exist” behavior intact.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8efaa97eeb9a881f58a98f0259367578da03039f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->