### PR TITLE
docs: add hybrid and keyword search references across documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,10 +268,10 @@ See **[LLM Providers](https://redis.github.io/agent-memory-server/llm-providers/
 ```
 Working Memory (Session-scoped)  →  Long-term Memory (Persistent)
     ↓                                      ↓
-- Messages                         - Semantic, keyword & hybrid search
-- Structured memories              - Topic modeling
-- Summary of past messages         - Entity recognition
-- Metadata                         - Deduplication
+|- Messages                        - Semantic, keyword & hybrid search
+|- Structured memories             - Topic modeling
+|- Summary of past messages        - Entity recognition
+|- Metadata                        - Deduplication
 ```
 
 ## Use Cases

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A memory layer for AI agents.
 - **Dual Interface**: REST API and Model Context Protocol (MCP) server
 - **Two-Tier Memory**: Working memory (session-scoped) and long-term memory (persistent)
 - **Configurable Memory Strategies**: Customize how memories are extracted (discrete, summary, preferences, custom)
-- **Semantic Search**: Vector-based similarity search with metadata filtering
+- **Semantic, Keyword & Hybrid Search**: Vector-based similarity, full-text keyword, and combined hybrid search with metadata filtering
 - **Flexible Backends**: Pluggable memory vector database factory system
 - **Multi-Provider LLM Support**: OpenAI, Anthropic, AWS Bedrock, Ollama, Azure, Gemini via [LiteLLM](https://docs.litellm.ai/)
 - **AI Integration**: Automatic topic extraction, entity recognition, and conversation summarization
@@ -268,7 +268,7 @@ See **[LLM Providers](https://redis.github.io/agent-memory-server/llm-providers/
 ```
 Working Memory (Session-scoped)  →  Long-term Memory (Persistent)
     ↓                                      ↓
-- Messages                         - Semantic search
+- Messages                         - Semantic, keyword & hybrid search
 - Structured memories              - Topic modeling
 - Summary of past messages         - Entity recognition
 - Metadata                         - Deduplication

--- a/agent-memory-client/README.md
+++ b/agent-memory-client/README.md
@@ -165,7 +165,7 @@ working_memory = WorkingMemory(
 response = await client.put_working_memory("user-session-123", working_memory)
 
 # Retrieve working memory
-memory = await client.get_working_memory("user-session-123")
+created, memory = await client.get_or_create_working_memory("user-session-123")
 
 # Convenience method for data storage
 await client.set_working_memory_data(
@@ -199,6 +199,21 @@ results = await client.search_long_term_memory(
     text="science fiction",
     topics=Topics(any=["books", "entertainment"]),
     user_id=UserId(eq="user-123"),
+    limit=20
+)
+
+# Keyword search - full-text matching
+results = await client.search_long_term_memory(
+    text="science fiction",
+    search_mode="keyword",
+    limit=20
+)
+
+# Hybrid search - combines semantic and keyword matching
+results = await client.search_long_term_memory(
+    text="science fiction",
+    search_mode="hybrid",
+    hybrid_alpha=0.7,  # 0.0=keyword, 1.0=semantic
     limit=20
 )
 ```
@@ -333,9 +348,9 @@ from agent_memory_client.exceptions import (
 )
 
 try:
-    memory = await client.get_working_memory("nonexistent-session")
-except MemoryNotFoundError:
-    print("Session not found")
+    created, memory = await client.get_or_create_working_memory("nonexistent-session")
+    if created:
+        print("New session created")
 except MemoryServerError as e:
     print(f"Server error {e.status_code}: {e}")
 except MemoryClientError as e:

--- a/agent-memory-client/README.md
+++ b/agent-memory-client/README.md
@@ -343,14 +343,15 @@ results = await client.search_long_term_memory(
 from agent_memory_client.exceptions import (
     MemoryClientError,
     MemoryValidationError,
-    MemoryNotFoundError,
     MemoryServerError
 )
 
 try:
-    created, memory = await client.get_or_create_working_memory("nonexistent-session")
+    created, memory = await client.get_or_create_working_memory("my-session")
     if created:
         print("New session created")
+except MemoryValidationError as e:
+    print(f"Validation error: {e}")
 except MemoryServerError as e:
     print(f"Server error {e.status_code}: {e}")
 except MemoryClientError as e:

--- a/agent-memory-client/agent-memory-client-js/README.md
+++ b/agent-memory-client/agent-memory-client-js/README.md
@@ -90,11 +90,26 @@ await client.createLongTermMemory([
   },
 ]);
 
-// Search with filters
+// Search with filters (default: semantic search)
 const results = await client.searchLongTermMemory({
   text: "science fiction",
   topics: new Topics({ any: ["books", "entertainment"] }),
   userId: new UserId({ eq: "user-123" }),
+  limit: 20,
+});
+
+// Keyword search - full-text matching
+const keywordResults = await client.searchLongTermMemory({
+  text: "science fiction",
+  searchMode: "keyword",
+  limit: 20,
+});
+
+// Hybrid search - combines semantic and keyword matching
+const hybridResults = await client.searchLongTermMemory({
+  text: "science fiction",
+  searchMode: "hybrid",
+  hybridAlpha: 0.7, // 0.0=keyword, 1.0=semantic
   limit: 20,
 });
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -75,7 +75,7 @@ For contributors and advanced users:
 
 | Feature | REST API | MCP Server | CLI | Documentation |
 |---------|----------|------------|-----|---------------|
-| **Memory Search** | ✅ `/v1/long-term-memory/search` | ✅ `search_long_term_memory` | ❌ | [REST API](api.md), [MCP](mcp.md) |
+| **Memory Search** (semantic, keyword, hybrid) | ✅ `/v1/long-term-memory/search` | ✅ `search_long_term_memory` | ❌ | [REST API](api.md), [MCP](mcp.md) |
 | **Memory Editing** | ✅ `PATCH /v1/long-term-memory/{id}` | ✅ `edit_long_term_memory` | ❌ | [Memory Editing](memory-lifecycle.md#memory-editing) |
 | **Query Optimization** | ✅ `optimize_query` param | ✅ `optimize_query` param | ❌ | [Query Optimization](query-optimization.md) |
 | **Recency Boost** | ✅ Default enabled | ✅ Available | ❌ | [Recency Boost](recency-boost.md) |

--- a/docs/README.md
+++ b/docs/README.md
@@ -75,7 +75,7 @@ For contributors and advanced users:
 
 | Feature | REST API | MCP Server | CLI | Documentation |
 |---------|----------|------------|-----|---------------|
-| **Memory Search** (semantic, keyword, hybrid) | ✅ `/v1/long-term-memory/search` | ✅ `search_long_term_memory` | ❌ | [REST API](api.md), [MCP](mcp.md) |
+| **Memory Search** (semantic, keyword, hybrid) | ✅ `/v1/long-term-memory/search` | ✅ `search_long_term_memory` | ✅ `agent-memory search` | [REST API](api.md), [MCP](mcp.md), [CLI](cli.md) |
 | **Memory Editing** | ✅ `PATCH /v1/long-term-memory/{id}` | ✅ `edit_long_term_memory` | ❌ | [Memory Editing](memory-lifecycle.md#memory-editing) |
 | **Query Optimization** | ✅ `optimize_query` param | ✅ `optimize_query` param | ❌ | [Query Optimization](query-optimization.md) |
 | **Recency Boost** | ✅ Default enabled | ✅ Available | ❌ | [Recency Boost](recency-boost.md) |

--- a/docs/agent-examples.md
+++ b/docs/agent-examples.md
@@ -402,7 +402,7 @@ from agent_memory_client import create_memory_client
 client = await create_memory_client(base_url="http://localhost:8000")
 
 # Get only the 3 most recent messages
-created, memory = await client.get_or_create_working_memory(
+_created, memory = await client.get_or_create_working_memory(
     session_id="my-session",
     namespace="demo",
     context_window_max=3

--- a/docs/agent-examples.md
+++ b/docs/agent-examples.md
@@ -93,7 +93,7 @@ A comprehensive travel assistant that demonstrates the most complete integration
 - **Automatic Tool Discovery**: Uses `MemoryAPIClient.get_all_memory_tool_schemas()` to automatically discover and integrate all available memory tools
 - **Unified Tool Resolution**: Leverages `client.resolve_tool_call()` to handle all memory tool calls uniformly across different LLM providers
 - **Working Memory Management**: Session-based conversation state and structured memory storage
-- **Long-term Memory**: Persistent memory storage and semantic search capabilities
+- **Long-term Memory**: Persistent memory storage with semantic, keyword, and hybrid search capabilities
 - **Optional Web Search**: Cached web search using Tavily API with Redis caching
 
 ### Available Tools
@@ -402,7 +402,7 @@ from agent_memory_client import create_memory_client
 client = await create_memory_client(base_url="http://localhost:8000")
 
 # Get only the 3 most recent messages
-memory = await client.get_working_memory(
+created, memory = await client.get_or_create_working_memory(
     session_id="my-session",
     namespace="demo",
     context_window_max=3

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,7 +38,7 @@ Transform your AI agents from goldfish 🐠 into elephants 🐘 with Redis-power
 Redis Agent Memory Server is a production-ready memory system for AI agents and applications that:
 
 - **🧠 Remembers everything**: Stores conversation history, user preferences, and important facts across sessions
-- **🔍 Finds relevant context**: Uses semantic search to surface the right information at the right time
+- **🔍 Finds relevant context**: Uses semantic, keyword, and hybrid search to surface the right information at the right time
 - **📈 Gets smarter over time**: Automatically extracts, organizes, and deduplicates memories from interactions
 - **🔌 Works with any AI model**: REST API and MCP interfaces compatible with OpenAI, Anthropic, and others
 - **🌐 Multi-provider support**: Use [100+ LLM providers](llm-providers.md) via LiteLLM (OpenAI, Anthropic, AWS Bedrock, Ollama, Azure, Gemini, and more)
@@ -95,11 +95,11 @@ print(f"Found: {results.memories[0].text}")
 
 !!! success "Long-Term Memory (Persistent)"
     - User preferences, facts, and important information
-    - Semantic search with vector embeddings
+    - Flexible search: semantic (vector embeddings), keyword (full-text), and hybrid (combined)
     - Advanced filtering by time, topics, entities, users
 
 ### 🔍 Intelligent Search
-- **Semantic similarity**: Find memories by meaning, not just keywords
+- **Multiple search modes**: Semantic (vector similarity), keyword (full-text), and hybrid (combined) search
 - **Advanced filters**: Search by user, session, time, topics, entities
 - **Query optimization**: AI-powered query refinement for better results
 - **Recency boost**: Time-aware ranking that surfaces relevant recent information

--- a/docs/java-sdk.md
+++ b/docs/java-sdk.md
@@ -144,6 +144,21 @@ MemoryRecordResults results = client.longTermMemory().searchLongTermMemories(req
 // Simple text search
 MemoryRecordResults simpleResults = client.longTermMemory()
     .searchLongTermMemories("user preferences");
+
+// Keyword search - full-text matching
+SearchRequest keywordRequest = SearchRequest.builder()
+    .text("TechCorp engineer")
+    .searchMode("keyword")
+    .limit(10)
+    .build();
+
+// Hybrid search - combines semantic and keyword matching
+SearchRequest hybridRequest = SearchRequest.builder()
+    .text("user preferences")
+    .searchMode("hybrid")
+    .hybridAlpha(0.7)  // 0.0=keyword, 1.0=semantic
+    .limit(10)
+    .build();
 ```
 
 ### Get, Edit, and Delete

--- a/docs/long-term-memory.md
+++ b/docs/long-term-memory.md
@@ -4,17 +4,17 @@ Long-term memory is **persistent**, **cross-session** storage designed for knowl
 
 ## Overview
 
-Long-term memory provides persistent storage that survives server restarts and session expiration. It's optimized for semantic search, deduplication, and rich metadata to enable intelligent retrieval of relevant information.
+Long-term memory provides persistent storage that survives server restarts and session expiration. It's optimized for semantic, keyword, and hybrid search, deduplication, and rich metadata to enable intelligent retrieval of relevant information.
 
 | Feature | Details |
 |---------|---------|
 | **Scope** | Cross-session, persistent |
 | **Lifespan** | Permanent until manually deleted |
-| **Storage** | Redis with vector indexing |
-| **Search** | Semantic vector search |
+| **Storage** | Redis with vector and full-text indexing |
+| **Search** | Semantic, keyword, and hybrid search |
 | **Capacity** | Unlimited (with compaction) |
 | **Use Case** | Knowledge base, user preferences |
-| **Indexing** | Vector embeddings + metadata |
+| **Indexing** | Vector embeddings + full-text index + metadata |
 | **Deduplication** | Hash-based and semantic |
 
 ## Characteristics
@@ -126,14 +126,35 @@ POST /v1/long-term-memory/search
 
 ## Search Capabilities
 
-Long-term memory provides powerful search features:
+Long-term memory supports three search modes: **semantic** (vector similarity), **keyword** (full-text matching), and **hybrid** (combined).
 
-### Semantic Vector Search
+### Semantic Search (Default)
 ```json
 {
   "text": "python programming help",
+  "search_mode": "semantic",
   "limit": 10,
   "distance_threshold": 0.8
+}
+```
+
+### Keyword Search
+```json
+{
+  "text": "TechCorp engineer",
+  "search_mode": "keyword",
+  "limit": 10
+}
+```
+
+### Hybrid Search
+Combines vector similarity with full-text keyword matching. Use `hybrid_alpha` to control the balance (0.0 = pure keyword, 1.0 = pure semantic, default 0.7).
+```json
+{
+  "text": "python programming help",
+  "search_mode": "hybrid",
+  "hybrid_alpha": 0.7,
+  "limit": 10
 }
 ```
 

--- a/docs/long-term-memory.md
+++ b/docs/long-term-memory.md
@@ -21,7 +21,7 @@ Long-term memory provides persistent storage that survives server restarts and s
 
 - **Cross-Session**: Accessible from any session
 - **Persistent**: Survives server restarts and session expiration
-- **Vector Indexed**: Semantic search with configurable embeddings (OpenAI, Bedrock, Ollama, and more via [LiteLLM](llm-providers.md))
+- **Multi-Modal Search**: Semantic (vector), keyword (BM25 full-text), and hybrid search — configurable embeddings (OpenAI, Bedrock, Ollama, and more via [LiteLLM](llm-providers.md))
 - **Deduplication**: Automatic hash-based and semantic deduplication
 - **Rich Metadata**: Topics, entities, timestamps, memory types
 - **Compaction**: Automatic cleanup and merging of duplicates

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -178,7 +178,7 @@ await memory_client.create_long_term_memory([
 
 ## Step 7: Search Your Memories
 
-Search across all stored memories with semantic similarity:
+Search across all stored memories using semantic similarity, keyword matching, or hybrid search:
 
 ```python
 # Search for work-related information
@@ -331,7 +331,7 @@ You've just worked with both types of memory:
 - **Scope**: Cross-session, persistent
 - **Lifetime**: Permanent until deleted
 - **Use case**: User preferences, facts, knowledge
-- **Search**: Semantic vector search with advanced filtering
+- **Search**: Semantic, keyword, and hybrid search with advanced filtering
 
 ## Next Steps
 
@@ -537,7 +537,7 @@ redis-cli -h localhost -p 6379
 
 You now have a working AI agent memory system! Your memories will:
 - ✅ Persist across sessions
-- ✅ Be searchable with semantic similarity
+- ✅ Be searchable with semantic, keyword, or hybrid search
 - ✅ Automatically extract context from conversations
 - ✅ Provide relevant context to AI responses
 

--- a/docs/typescript-sdk.md
+++ b/docs/typescript-sdk.md
@@ -106,9 +106,24 @@ import {
   MemoryType,
 } from "agent-memory-client";
 
-// Basic search
+// Basic semantic search (default)
 const results = await client.searchLongTermMemory({
   text: "user preferences",
+  limit: 10,
+});
+
+// Keyword search - full-text matching
+const keywordResults = await client.searchLongTermMemory({
+  text: "TechCorp engineer",
+  searchMode: "keyword",
+  limit: 10,
+});
+
+// Hybrid search - combines semantic and keyword matching
+const hybridResults = await client.searchLongTermMemory({
+  text: "user preferences",
+  searchMode: "hybrid",
+  hybridAlpha: 0.7, // 0.0=keyword, 1.0=semantic
   limit: 10,
 });
 

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -701,7 +701,7 @@ guidance = await health.get_contextual_health_guidance(
 ### Search Optimization
 - **Enable recency boost**: For time-sensitive domains like support or health
 - **Use query optimization**: For natural language queries from end users
-- **Filter strategically**: Combine semantic search with metadata filters
+- **Filter strategically**: Combine semantic, keyword, or hybrid search with metadata filters
 
 ### Privacy and Security
 - **User isolation**: Always filter by user_id for personal data

--- a/examples/README.md
+++ b/examples/README.md
@@ -51,7 +51,7 @@ A comprehensive travel assistant that demonstrates:
 - **Automatic Tool Discovery**: Uses `MemoryAPIClient.get_all_memory_tool_schemas()` to automatically discover and integrate all available memory tools
 - **Unified Tool Resolution**: Leverages `client.resolve_tool_call()` to handle all memory tool calls uniformly across different LLM providers
 - **Working Memory Management**: Session-based conversation state and structured memory storage
-- **Long-term Memory**: Persistent memory storage and semantic search capabilities
+- **Long-term Memory**: Persistent memory storage with semantic, keyword, and hybrid search capabilities
 - **Optional Web Search**: Cached web search using Tavily API with Redis caching
 
 ### Available Tools


### PR DESCRIPTION
## Summary

Update all documentation and READMEs to consistently describe search as supporting semantic, keyword, and hybrid modes instead of only semantic.

This is Part 1 of 2 PRs split from #251 to make review easier. This PR contains only documentation changes. Part 2 (core fix + MCP) builds on this branch.

## Changes

- Expand feature descriptions across all docs to include keyword and hybrid search
- Add SDK usage examples (Python, TypeScript/JS, Java) for keyword and hybrid search modes
- Add full-text indexing table to long-term memory docs showing which fields are indexed
- Fix deprecated function reference in agent examples (`get_working_memory` to `get_or_create_working_memory`)
- Fix tuple unpacking order in error handling example
- Update search capability descriptions across all guides and READMEs

## Files Changed (12)

- `README.md`
- `docs/README.md`, `docs/index.md`, `docs/long-term-memory.md`, `docs/quick-start.md`, `docs/use-cases.md`, `docs/java-sdk.md`, `docs/typescript-sdk.md`, `docs/agent-examples.md`
- `examples/README.md`
- `agent-memory-client/README.md`, `agent-memory-client/agent-memory-client-js/README.md`

## Context

The server already supports keyword (BM25) and hybrid (RRF) search modes via the `search_mode` parameter, but documentation only referenced semantic search. This brings docs in line with actual capabilities.

Per discussion on #251 (@vishal-bala, @abrookins, @tylerhutcherson, @nkanu17): MCP documentation for search modes is in Part 2 alongside the code changes, since MCP docs should stay coupled with the MCP implementation.

## Review Notes

- No code behavior changes in this PR
- All changes are documentation and examples only
- `docs/mcp.md` changes are intentionally in Part 2

Refs: #251 (superseded by this PR and #265), #253 (tracking issue for remaining MCP/REST gaps)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only changes that update examples and wording; low risk aside from potential confusion if any SDK/API names are misstated.
> 
> **Overview**
> Updates documentation and SDK READMEs to consistently describe long-term memory search as supporting **semantic, keyword, and hybrid** modes (including new `search_mode`/`hybrid_alpha` examples in Python, JS/TS, and Java).
> 
> Fixes/refreshes a few examples to match current APIs (e.g., use `get_or_create_working_memory` and correct tuple unpacking/error-handling snippets) and adjusts feature matrices/architecture diagrams to reflect the expanded search options.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 69765bba5f98cdca7ea5e331cf50bc7ce083b976. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

