### PR TITLE
feat(mcp): wire up oauth2 token verification for streamable-http transport

### DIFF
--- a/agent_memory_server/config.py
+++ b/agent_memory_server/config.py
@@ -427,6 +427,7 @@ class Settings(BaseSettings):
     oauth2_audience: str | None = None
     oauth2_jwks_url: str | None = None
     oauth2_algorithms: list[str] = ["RS256"]
+    oauth2_resource_host: str | None = None
 
     # Token Authentication settings
     token_auth_enabled: bool = False

--- a/agent_memory_server/main.py
+++ b/agent_memory_server/main.py
@@ -130,6 +130,17 @@ app.include_router(health_router)
 app.include_router(memory_router)
 
 
+@app.get("/.well-known/oauth-authorization-server")
+async def oauth_authorization_server_metadata():
+    """RFC 9728 Protected Resource Metadata for MCP OIDC discovery."""
+    if not settings.oauth2_issuer_url:
+        return {"error": "OIDC not configured"}
+    return {
+        "resource": f"https://{settings.oauth2_resource_host or 'localhost'}",
+        "authorization_servers": [settings.oauth2_issuer_url],
+    }
+
+
 def on_start_logger(port: int):
     """Log startup information"""
     print("\n-----------------------------------")

--- a/agent_memory_server/mcp.py
+++ b/agent_memory_server/mcp.py
@@ -3,6 +3,8 @@ from datetime import datetime
 from typing import Any
 
 import ulid
+from mcp.server.auth.provider import AccessToken, TokenVerifier
+from mcp.server.auth.settings import AuthSettings
 from mcp.server.fastmcp import FastMCP as _FastMCPBase
 
 from agent_memory_server import working_memory as working_memory_core
@@ -179,22 +181,16 @@ class FastMCP(_FastMCPBase):
         ).serve()
 
     def streamable_http_app(self):
-        """Return a Starlette app for streamable-http with namespace routing."""
-        from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
-        from starlette.applications import Starlette
+        """Return a Starlette app for streamable-http with namespace routing.
+
+        Extends the parent's streamable_http_app() by adding a namespace-prefixed
+        route while preserving auth middleware and protected resource routes.
+        """
         from starlette.requests import Request
         from starlette.routing import Route
 
-        if self._session_manager is None:
-            self._session_manager = StreamableHTTPSessionManager(
-                app=self._mcp_server,
-                event_store=self._event_store,
-                retry_interval=self._retry_interval,
-                json_response=self.settings.json_response,
-                stateless=self.settings.stateless_http,
-                security_settings=self.settings.transport_security,
-            )
-
+        # Get the parent's app which includes auth middleware and well-known routes
+        app = super().streamable_http_app()
         session_manager = self._session_manager
         mcp_instance = self
 
@@ -212,14 +208,9 @@ class FastMCP(_FastMCPBase):
         handler = _NamespaceAwareHandler()
         path = self.settings.streamable_http_path
 
-        return Starlette(
-            debug=self.settings.debug,
-            routes=[
-                Route(path, endpoint=handler),
-                Route(f"/{{namespace}}{path}", endpoint=handler),
-            ],
-            lifespan=lambda app: session_manager.run(),
-        )
+        # Add namespace-prefixed route to the existing app
+        app.routes.append(Route(f"/{{namespace}}{path}", endpoint=handler))
+        return app
 
     async def run_streamable_http_async(self):
         """Start streamable HTTP MCP server."""
@@ -255,12 +246,51 @@ INSTRUCTIONS = """
 """
 
 
+class JWTTokenVerifier(TokenVerifier):
+    """Verify JWT tokens from Hydra using the existing auth module."""
+
+    async def verify_token(self, token: str) -> AccessToken | None:
+        from agent_memory_server.auth import verify_jwt
+
+        try:
+            user_info = verify_jwt(token)
+            scopes = user_info.scope.split() if user_info.scope else []
+            return AccessToken(
+                token=token,
+                client_id=user_info.sub,
+                scopes=scopes,
+                expires_at=user_info.exp,
+            )
+        except Exception:
+            return None
+
+
+def _build_mcp_auth_kwargs() -> dict[str, Any]:
+    """Build auth kwargs for FastMCP if OAuth2 is configured."""
+    if (
+        settings.auth_mode != "oauth2"
+        or not settings.oauth2_issuer_url
+        or not settings.oauth2_resource_host
+    ):
+        return {}
+
+    resource_url = f"https://{settings.oauth2_resource_host}"
+    return {
+        "auth": AuthSettings(
+            issuer_url=settings.oauth2_issuer_url,
+            resource_server_url=resource_url,
+        ),
+        "token_verifier": JWTTokenVerifier(),
+    }
+
+
 mcp_app = FastMCP(
     "Redis Agent Memory Server",
     host=settings.mcp_host,
     port=settings.mcp_port,
     instructions=INSTRUCTIONS,
     default_namespace=settings.default_mcp_namespace,
+    **_build_mcp_auth_kwargs(),
 )
 
 


### PR DESCRIPTION
## Problem

The MCP SDK (v1.26.0+) has built-in OAuth 2.1 support via `AuthSettings`, `TokenVerifier`, and `RequireAuthMiddleware`. The agent-memory-server's existing `auth.py` handles JWT validation for the REST API (`/v1/*` endpoints), but the MCP streamable-http transport (`/mcp` endpoint) never wires this up to the SDK's auth layer.

When an MCP client (e.g., Claude) connects to `/mcp` without a Bearer token, the transport returns a `406 Not Acceptable` error instead of `401` with a `WWW-Authenticate` header. Without that header, clients cannot discover the OAuth authorization server and the login flow never triggers.

The REST API and MCP transport are two separate ASGI apps — the FastAPI auth middleware on the REST side does not protect the MCP side.

## Fix

Three small changes:

### 1. `JWTTokenVerifier` in `mcp.py`

Implements the SDK's `TokenVerifier` protocol by wrapping the existing `verify_jwt()` function from `auth.py`. Converts `UserInfo` (the REST API's auth model) to `AccessToken` (the SDK's auth model).

### 2. Conditional `AuthSettings` in `mcp.py`

`_build_mcp_auth_kwargs()` returns `auth` + `token_verifier` kwargs for `FastMCP` only when `AUTH_MODE=oauth2` and `OAUTH2_RESOURCE_HOST` are set. When disabled, no kwargs are passed and behavior is unchanged.

When enabled, the SDK's built-in middleware:
- Returns `401` with `WWW-Authenticate: Bearer resource_metadata="..."` for unauthenticated requests
- Serves `/.well-known/oauth-protected-resource` automatically
- Validates JWT tokens on all MCP requests via JWKS

### 3. `/.well-known/oauth-authorization-server` endpoint in `main.py`

RFC 9728 Protected Resource Metadata endpoint on the REST API side. Returns the resource server URL and authorization server URL so clients can discover where to authenticate.

### 4. `OAUTH2_RESOURCE_HOST` config setting

New optional setting for the server's public hostname (e.g., `agent-memory.loft.rocks`). Used to construct the `resource` field in metadata responses.

## Configuration

```bash
# Enable MCP OAuth (in addition to existing REST API OAuth2 settings)
AUTH_MODE=oauth2
OAUTH2_ISSUER_URL=https://your-oidc-provider.example.com/
OAUTH2_RESOURCE_HOST=your-server.example.com
# Optional: OAUTH2_AUDIENCE for JWT audience validation (existing setting)
```

When `AUTH_MODE` is not `oauth2` or `OAUTH2_RESOURCE_HOST` is unset, the MCP transport runs without auth — same as before this change.

## Test plan

- [x] 53/53 existing auth tests pass
- [x] `_build_mcp_auth_kwargs()` returns correct settings when configured
- [x] `_build_mcp_auth_kwargs()` returns empty dict when unconfigured
- [ ] `curl -H "Accept: text/event-stream" https://server/mcp` returns 401 + `WWW-Authenticate` header
- [ ] MCP client (Claude) discovers OAuth flow and completes login
- [ ] After login, MCP tools work with valid JWT

Tested with Ory Hydra as the OIDC provider and Claude as the MCP client.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication and request routing for the MCP transport; misconfiguration or verifier/middleware integration issues could cause unexpected 401/406 behavior or block clients from connecting.
> 
> **Overview**
> Wires the MCP `streamable-http` transport into the MCP SDK’s OAuth2 auth layer by conditionally passing `AuthSettings` and a new `JWTTokenVerifier` that adapts the server’s existing `verify_jwt()` validation to the SDK’s `TokenVerifier` interface.
> 
> Adds a new `/.well-known/oauth-authorization-server` endpoint on the REST app to publish protected-resource/authorization-server metadata (using new `oauth2_resource_host` config), and updates the MCP `streamable_http_app()` override to extend the parent app so auth middleware and well-known routes are preserved while still supporting namespace-prefixed routing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f5dc326440b4444d6a1d4abcfcc1d29c2bac967. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->