### PR TITLE
feat(java-client): allow caller-supplied OkHttpClient injection

### DIFF
--- a/agent-memory-client/agent-memory-client-java/build.gradle.kts
+++ b/agent-memory-client/agent-memory-client-java/build.gradle.kts
@@ -36,7 +36,8 @@ repositories {
 
 dependencies {
     // HTTP Client
-    implementation("com.squareup.okhttp3:okhttp:4.12.0")
+    // api so that `Builder.httpClient` callers can avoid version skew
+    api("com.squareup.okhttp3:okhttp:4.12.0")
 
     // JSON Processing
     implementation("com.fasterxml.jackson.core:jackson-databind:2.16.1")

--- a/agent-memory-client/agent-memory-client-java/src/main/java/com/redis/agentmemory/MemoryAPIClient.java
+++ b/agent-memory-client/agent-memory-client-java/src/main/java/com/redis/agentmemory/MemoryAPIClient.java
@@ -36,6 +36,7 @@ public class MemoryAPIClient implements AutoCloseable {
     private final String defaultModelName;
     private final Integer defaultContextWindowMax;
     private final OkHttpClient httpClient;
+    private final boolean ownsHttpClient;
     private final ObjectMapper objectMapper;
 
     // Service instances
@@ -53,10 +54,17 @@ public class MemoryAPIClient implements AutoCloseable {
         this.defaultModelName = builder.defaultModelName;
         this.defaultContextWindowMax = builder.defaultContextWindowMax;
 
-        this.httpClient = new OkHttpClient.Builder()
-                .connectTimeout((long) timeout, TimeUnit.SECONDS)
-                .readTimeout((long) timeout, TimeUnit.SECONDS)
-                .writeTimeout((long) timeout, TimeUnit.SECONDS)
+        OkHttpClient.Builder httpClientBuilder = builder.httpClient != null
+                ? builder.httpClient.newBuilder()
+                : new OkHttpClient.Builder()
+                        .connectTimeout((long) timeout, TimeUnit.SECONDS)
+                        .readTimeout((long) timeout, TimeUnit.SECONDS)
+                        .writeTimeout((long) timeout, TimeUnit.SECONDS);
+
+        // when the caller provides a client, we don't own it's lifecycle
+        this.ownsHttpClient = builder.httpClient == null;
+
+        this.httpClient = httpClientBuilder
                 .addInterceptor(chain -> {
                     Request original = chain.request();
                     Request request = original.newBuilder()
@@ -161,8 +169,11 @@ public class MemoryAPIClient implements AutoCloseable {
 
     @Override
     public void close() {
-        httpClient.dispatcher().executorService().shutdown();
-        httpClient.connectionPool().evictAll();
+        // when the caller provides a client, we don't own it's lifecycle
+        if (ownsHttpClient) {
+            httpClient.dispatcher().executorService().shutdown();
+            httpClient.connectionPool().evictAll();
+        }
     }
 
     /**
@@ -355,6 +366,7 @@ public class MemoryAPIClient implements AutoCloseable {
         private String defaultNamespace = null;
         private String defaultModelName = null;
         private Integer defaultContextWindowMax = null;
+        private OkHttpClient httpClient = null;
 
         private Builder(@NotNull String baseUrl) {
             this.baseUrl = baseUrl;
@@ -397,6 +409,19 @@ public class MemoryAPIClient implements AutoCloseable {
          */
         public Builder defaultContextWindowMax(@Nullable Integer defaultContextWindowMax) {
             this.defaultContextWindowMax = defaultContextWindowMax;
+            return this;
+        }
+
+        /**
+         * Sets an {@link OkHttpClient} to use for all requests.
+         *
+         * <p>
+         * When provided, the {@link #timeout(double)} settings is ignored.
+         * @param httpClient the OkHttpClient to use, or null to use the default
+         * @return this builder
+         */
+        public Builder httpClient(@Nullable OkHttpClient httpClient) {
+            this.httpClient = httpClient;
             return this;
         }
 

--- a/agent-memory-client/agent-memory-client-java/src/test/java/com/redis/agentmemory/MemoryAPIClientTest.java
+++ b/agent-memory-client/agent-memory-client-java/src/test/java/com/redis/agentmemory/MemoryAPIClientTest.java
@@ -6,6 +6,7 @@ import com.redis.agentmemory.exceptions.*;
 import com.redis.agentmemory.models.common.AckResponse;
 import com.redis.agentmemory.models.longtermemory.*;
 import com.redis.agentmemory.models.workingmemory.*;
+import okhttp3.OkHttpClient;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
@@ -402,6 +403,62 @@ class MemoryAPIClientTest {
         assertNotNull(response);
         assertEquals("ok", response.getStatus());
         assertEquals(1, mockServer.getRequestCount()); // Only GET, no CREATE
+    }
+
+    @Test
+    void testCustomHttpClientReachesServer() throws Exception {
+        // caller-supplied client
+        OkHttpClient customClient = new OkHttpClient.Builder()
+                .addInterceptor(chain -> chain.proceed(
+                        chain.request().newBuilder()
+                                .header("X-Custom-Header", "custom-header-value")
+                                .build()))
+                .build();
+
+        try (MemoryAPIClient customizedClient = MemoryAPIClient.builder(mockServer.url("/").toString())
+                .httpClient(customClient)
+                .build()) {
+
+            mockServer.enqueue(new MockResponse()
+                .setBody("{}")
+                .addHeader("Content-Type", "application/json"));
+
+            customizedClient.health().healthCheck();
+
+            RecordedRequest request = mockServer.takeRequest();
+            // provided client headers
+            assertEquals("custom-header-value", request.getHeader("X-Custom-Header"));
+            // normal headers
+            assertTrue(request.getHeader("User-Agent").startsWith("agent-memory-client-java/"));
+            assertNotNull(request.getHeader("X-Client-Version"));
+        }
+    }
+
+    @Test
+    void testDefaultHttpClientHeaders() throws Exception {
+        mockServer.enqueue(new MockResponse()
+                .setBody("{}")
+                .addHeader("Content-Type", "application/json"));
+
+        client.health().healthCheck();
+
+        RecordedRequest request = mockServer.takeRequest();
+        assertTrue(request.getHeader("User-Agent").startsWith("agent-memory-client-java/"));
+        assertNotNull(request.getHeader("X-Client-Version"));
+    }
+
+    @Test
+    void testCloseDoesNotShutDownCallerSuppliedClient() throws Exception {
+        OkHttpClient customClient = new OkHttpClient.Builder().build();
+
+        MemoryAPIClient customizedClient = MemoryAPIClient.builder(mockServer.url("/").toString())
+                .httpClient(customClient)
+                .build();
+
+        customizedClient.close();
+
+        assertFalse(customClient.dispatcher().executorService().isShutdown(),
+                "caller-supplied client's executor must survive MemoryAPIClient.close()");
     }
 
     // ===== Tests for Phase 2: Convenience Overloads =====


### PR DESCRIPTION
adds a backwards-compatible `Builder.httpClient(OkHttpClient)` method: when set, the `OkHttp` client used downstream is derived from the caller's; otherwise, the existing default client is built.

when a client is provided:

- `timeout` setting is ignored
- don't close on '#close()', the library doesn't own it

in both cases
- the `User-Agent`/`X-Client-Version` interceptor is added

additionally, expose okhttp as `api` (not `implementation`) so consumers can build their own OkHttpClient against the same okhttp version the client uses.

tests:
- caller supplied interceptor reaches the server
- user-agent/x-client-version remain with custom client
- user-agent/x-client-version remain with default client
- close() leaves the caller supplied client usable

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Backward-compatible builder extension and dependency visibility change; lifecycle fix reduces risk of breaking shared OkHttp pools on close.
> 
> **Overview**
> Adds optional **`Builder.httpClient(OkHttpClient)`** so integrators can reuse a shared OkHttp instance (custom interceptors, connection pooling, TLS). When set, the client is built via **`newBuilder()`** on the supplied instance, **`timeout()` is not applied**, and **`close()`** no longer shuts down the dispatcher or evicts the pool—the library only tears down HTTP resources for its default-built client.
> 
> **OkHttp** is published as an **`api`** dependency so consumers compile against the same OkHttp version as the client. The library still adds its **`User-Agent`** / **`X-Client-Version`** interceptor in both paths.
> 
> Tests cover custom interceptors reaching the wire, default and custom client headers, and that **`close()`** leaves a caller-owned client usable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c137d7eb18cfc660ac8285cc8971ff58b8ef9ab8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->