### PR TITLE
Add warning when optimize_query is used with non-semantic search modes.

### DIFF
--- a/V0/agent_memory_server/long_term_memory.py
+++ b/V0/agent_memory_server/long_term_memory.py
@@ -1434,6 +1434,12 @@ async def search_long_term_memories(
     # preserve the literal text for lexical matching.
     search_query = text
     optimized_applied = False
+
+    if optimize_query and search_mode != SearchModeEnum.SEMANTIC:
+        # log a message? 
+        logger.warning(f"optimize_query=True is only supported for semantic search, but search_mode='{search_mode.value}'")
+
+
     if optimize_query and text and search_mode == SearchModeEnum.SEMANTIC:
         search_query = await optimize_query_for_vector_search(text)
         optimized_applied = True

--- a/V0/agent_memory_server/summary_views.py
+++ b/V0/agent_memory_server/summary_views.py
@@ -167,10 +167,6 @@ async def delete_summary_view(view_id: str) -> None:
         if cursor == 0:
             break
 
-
-
-
-
 async def save_partition_result(result: SummaryViewPartitionResult) -> None:
     """Persist a single partition result for a SummaryView."""
 

--- a/V0/agent_memory_server/summary_views.py
+++ b/V0/agent_memory_server/summary_views.py
@@ -150,10 +150,25 @@ async def delete_summary_view(view_id: str) -> None:
     Stored partition summaries are left as-is for now; they can be cleaned
     up in a later pass if needed.
     """
+    cursor = 0
 
     redis = await get_redis_conn()
     await redis.delete(_config_key(view_id))
     await redis.srem(_SUMMARY_VIEW_INDEX_KEY, view_id)
+
+    pattern = _summary_key(view_id, "*")
+
+    while True: 
+        cursor, keys = await redis.scan(cursor=cursor, match=pattern, count=100) 
+
+        for key in keys:
+            await redis.delete(key)
+
+        if cursor == 0:
+            break
+
+
+
 
 
 async def save_partition_result(result: SummaryViewPartitionResult) -> None:


### PR DESCRIPTION
- Logs warning if optimize_query=True but search_mode is KEYWORD or HYBRID
- addresses issue #252 (option 4)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only change in search path; no change to query handling or search results.
> 
> **Overview**
> When **`optimize_query=True`** is passed to **`search_long_term_memories`** but **`search_mode`** is not semantic (keyword or hybrid), the server now emits a **`logger.warning`** stating that query optimization applies only to semantic search.
> 
> Behavior is unchanged: lexical modes still use the original query text; only semantic search may call **`optimize_query_for_vector_search`**. The warning helps callers who enable optimization globally or via APIs that do not vary by mode (issue #252).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ecf0fd8352657feff8c2bdc21b3613fb4fe079b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->