### PR TITLE
Add warning when optimize_query is used with non-semantic search modes.

### DIFF
--- a/V0/agent_memory_server/long_term_memory.py
+++ b/V0/agent_memory_server/long_term_memory.py
@@ -1434,6 +1434,10 @@ async def search_long_term_memories(
     # preserve the literal text for lexical matching.
     search_query = text
     optimized_applied = False
+
+    if optimize_query and search_mode != SearchModeEnum.SEMANTIC:
+            logger.warning(f"optimize_query=True is only supported for semantic search, but search_mode='{search_mode.value}'")
+
     if optimize_query and text and search_mode == SearchModeEnum.SEMANTIC:
         search_query = await optimize_query_for_vector_search(text)
         optimized_applied = True


### PR DESCRIPTION
Fix #252

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 3c0f5aa6a5df90c344d89a814c56aad4e369ed1f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->