### PR TITLE
Clean up orphaned partition summaries when deleting summary views

### DIFF
--- a/V0/agent_memory_server/summary_views.py
+++ b/V0/agent_memory_server/summary_views.py
@@ -151,10 +151,23 @@ async def delete_summary_view(view_id: str) -> None:
     up in a later pass if needed.
     """
 
+    cursor = 0
+
     redis = await get_redis_conn()
     await redis.delete(_config_key(view_id))
     await redis.srem(_SUMMARY_VIEW_INDEX_KEY, view_id)
 
+    pattern = _summary_key(view_id, "*")
+
+    while True: 
+        cursor, keys = await redis.scan(cursor=cursor, match=pattern, count=100) 
+
+        for key in keys:
+            await redis.delete(key)
+
+        if cursor == 0:
+            break
+        
 
 async def save_partition_result(result: SummaryViewPartitionResult) -> None:
     """Persist a single partition result for a SummaryView."""


### PR DESCRIPTION
## What
When a SummaryView is deleted, also remove all associated computed partition 
summaries (summary_view:{view_id}:summary:*) from Redis.

## Why
Previously these keys were left behind as orphaned data. Over time or across 
reset cycles, they accumulate and consume memory unnecessarily.

## How
Use SCAN to iterate through all partition summary keys matching the view ID, 
then DELETE each one. This follows the existing SCAN pattern used elsewhere 
in the codebase.

Fixes #229

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 06a7ba76d4019427f0c9e07b6d97b5b2ed0c6cce. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->