### PR TITLE
Restore GitHub Pages with Redis Agent Memory landing page

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,68 @@
+name: Deploy Documentation
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'V0/landing/**'
+      - 'V0/mkdocs.pages.yml'
+      - '.github/workflows/docs.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'V0/landing/**'
+      - 'V0/mkdocs.pages.yml'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: V0
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.13'
+
+      - name: Install MkDocs
+        run: python -m pip install mkdocs-material
+
+      - name: Setup Pages
+        if: github.ref == 'refs/heads/main'
+        uses: actions/configure-pages@v6
+
+      - name: Build landing page
+        run: mkdocs build --config-file mkdocs.pages.yml --clean --strict
+
+      - name: Upload artifact
+        if: github.ref == 'refs/heads/main'
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: V0/site
+
+  deploy:
+    if: github.ref == 'refs/heads/main'
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/V0/landing/index.md
+++ b/V0/landing/index.md
@@ -1,0 +1,32 @@
+---
+hide:
+  - navigation
+  - toc
+  - footer
+---
+
+# Redis Agent Memory
+
+## Give your AI agents memory that lasts
+
+Redis Agent Memory is the supported Redis service for persistent agent memory.
+It gives AI agents fast session memory and durable long-term memory through a
+REST API and client libraries. It includes secure API key management,
+configurable memory schemas, and automatic TTL-based lifecycle management.
+
+Redis Agent Memory is part of [Redis Iris](https://redis.io/iris/), the
+real-time context engine for agents.
+
+[Read the official documentation](https://redis.io/docs/latest/develop/ai/context-engine/agent-memory/){ .md-button .md-button--primary }
+[Explore Redis Agent Memory](https://redis.io/agent-memory/){ .md-button }
+
+---
+
+## Looking for the original open-source server?
+
+The original Redis Agent Memory Server is still available as an open-source
+research foundation. You can use it to learn, experiment, and review the
+reference implementation, but it is not the supported production path.
+
+[Browse the open-source server documentation](https://github.com/redis/agent-memory-server/blob/main/V0/docs/index.md){ .md-button }
+[View the source](https://github.com/redis/agent-memory-server/tree/main/V0){ .md-button }

--- a/V0/mkdocs.pages.yml
+++ b/V0/mkdocs.pages.yml
@@ -1,0 +1,40 @@
+site_name: Redis Agent Memory
+site_description: The supported Redis product for persistent agent memory
+site_url: https://redis.github.io/agent-memory-server/
+repo_url: https://github.com/redis/agent-memory-server
+repo_name: redis/agent-memory-server
+
+docs_dir: landing
+site_dir: site
+
+theme:
+  name: material
+  palette:
+    - media: "(prefers-color-scheme)"
+      toggle:
+        icon: material/brightness-auto
+        name: Switch to light mode
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: red
+      accent: red
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: red
+      accent: red
+      toggle:
+        icon: material/brightness-4
+        name: Switch to system preference
+  icon:
+    repo: fontawesome/brands/github
+
+nav:
+  - Redis Agent Memory: index.md
+
+plugins: []
+
+markdown_extensions:
+  - attr_list


### PR DESCRIPTION
## Summary

- restore the GitHub Pages deployment with a new one-page MkDocs build
- direct visitors to the supported Redis Agent Memory product and official documentation
- keep the original open-source server documentation unpublished and link to its Markdown source on GitHub

The landing page uses a separate MkDocs configuration and source directory. This prevents the legacy `V0/docs/` content from entering the published artifact.

## How Has This Been Tested?

- `pre-commit run --all-files`
- strict MkDocs build with `mkdocs build --config-file mkdocs.pages.yml --clean --strict`
- verified every external landing-page link returns HTTP 200
- previewed the generated page through the local MkDocs server

## Linked Items

None.

## Breaking Changes

None.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and CI-only changes; no application runtime, auth, or data paths affected.
> 
> **Overview**
> **Restores GitHub Pages** with a dedicated one-page MkDocs site instead of publishing legacy `V0/docs/`.
> 
> A new **`.github/workflows/docs.yml`** workflow builds on push/PR when `V0/landing/**`, `V0/mkdocs.pages.yml`, or the workflow file change; on `main` it uploads `V0/site` and deploys via GitHub Pages (`pages` / `id-token` permissions, `mkdocs-material`, strict `mkdocs build`).
> 
> **`V0/mkdocs.pages.yml`** points `docs_dir` at `landing` and sets the published URL to `https://redis.github.io/agent-memory-server/`, isolating the artifact from open-source server docs.
> 
> **`V0/landing/index.md`** is the public landing: product positioning, links to official Redis Agent Memory / Iris docs, and a section that routes OSS users to GitHub source and `V0/docs` Markdown rather than hosting that tree on Pages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c09e4f2bff2f68a8383744e769b2971c571cb0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->